### PR TITLE
unit tests no longer depend on mtime resoultion

### DIFF
--- a/test/unit/application_watcher_test.rb
+++ b/test/unit/application_watcher_test.rb
@@ -1,5 +1,6 @@
 require "helper"
 require "fileutils"
+require "active_support/core_ext/numeric/time"
 require "spring/application_watcher"
 
 class ApplicationWatcherTest < Test::Unit::TestCase
@@ -12,21 +13,21 @@ class ApplicationWatcherTest < Test::Unit::TestCase
     FileUtils.rm_r(@dir)
   end
 
-  def touch(file)
-    sleep 0.01
-    File.write(file, "omg")
+  def touch(file, mtime = nil)
+    options = {}
+    options[:mtime] = mtime if mtime
+    FileUtils.touch(file, options)
   end
 
   def test_file_mtime
     file = "#{@dir}/omg"
-    touch file
+    touch file, Time.now - 2.seconds
 
     watcher = Spring::ApplicationWatcher.new
     watcher.add_files [file]
 
     assert !watcher.stale?
-
-    touch file
+    touch file, Time.now
     assert watcher.stale?
   end
 
@@ -39,16 +40,16 @@ class ApplicationWatcherTest < Test::Unit::TestCase
 
     assert !watcher.stale?
 
-    touch "#{@dir}/1/foo"
+    touch "#{@dir}/1/foo", Time.now - 1.minute
     assert !watcher.stale?
 
-    touch "#{@dir}/1/foo.rb"
+    touch "#{@dir}/1/foo.rb", 2.seconds
     assert watcher.stale?
 
     watcher.reset
     assert !watcher.stale?
 
-    touch "#{@dir}/2/foo"
+    touch "#{@dir}/2/foo", Time.now
     assert watcher.stale?
   end
 end


### PR DESCRIPTION
OSX's filesystem does not have a mtime resolution with milliseconds. I changed the tests to use relative timestamps generated with `Time.now` to make it work with different mtime resolutions.
