### PR TITLE
run unit-tests and acceptance-tests separate to get faster feedback

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,21 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
-Rake::TestTask.new do |t|
-  t.libs << "test"
-  t.test_files = FileList["test/{acceptance,unit}/*_test.rb"]
-  t.verbose = true
+namespace :test do
+  Rake::TestTask.new(:unit) do |t|
+    t.libs << "test"
+    t.test_files = FileList["test/unit/*_test.rb"]
+    t.verbose = true
+  end
+
+  Rake::TestTask.new(:acceptance) do |t|
+    t.libs << "test"
+    t.test_files = FileList["test/acceptance/*_test.rb"]
+    t.verbose = true
+  end
+
+  desc 'run all tests'
+  task all: [:unit, :acceptance]
 end
 
-task default: :test
+task default: 'test:all'


### PR DESCRIPTION
I noticed that the acceptance tests take quite a while to run. (and currently don't work on OS-X ;). I like to run the tests suites separate to get faster feedback when things go wrong.

This is just my preference, if you like running everything in one go, just close the PR.
