### PR TITLE
we don't care about peoples .rvmrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.rvmrc
 Gemfile.lock
 InstalledFiles
 _yardoc


### PR DESCRIPTION
I use rvm gemsets locally to separate my projects. I think we can ignore them if someone wants to use them.
