### PR TITLE
fix file descripter was not passed on OS-X

### DIFF
--- a/lib/spring.rb
+++ b/lib/spring.rb
@@ -59,6 +59,7 @@ class Spring
     server.write rails_env_for(args.first)
     server.close
 
+    application.gets
     client.close
 
     application.send_io STDOUT

--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -39,8 +39,6 @@ class Spring
       watcher.add_files $LOADED_FEATURES
       watcher.add_files ["Gemfile", "Gemfile.lock"].map { |f| "#{Rails.root}/#{f}" }
       watcher.add_globs Rails.application.paths["config/initializers"].map { |p| "#{Rails.root}/#{p}/*.rb" }
-
-      run
     end
 
     def run
@@ -57,6 +55,7 @@ class Spring
     end
 
     def serve(client)
+      client.puts
       redirect_output(client) do
         args_length = client.gets.to_i
         args        = args_length.times.map { client.read(client.gets.to_i) }

--- a/lib/spring/application_manager.rb
+++ b/lib/spring/application_manager.rb
@@ -54,9 +54,17 @@ class Spring
       @child, child_socket = UNIXSocket.pair
       @pid = fork {
         [STDOUT, STDERR].each { |s| s.reopen('/dev/null', 'w') } if silence
-        @client.close if @client
         ENV['RAILS_ENV'] = ENV['RACK_ENV'] = env
-        Application.new(child_socket).start
+        application = Application.new(child_socket)
+        begin
+          application.start
+        rescue => e
+          @client.puts
+          raise e
+        ensure
+          @client.close if @client
+        end
+        application.run
       }
       child_socket.close
     end


### PR DESCRIPTION
The error "recv_io': file descriptor was not passed..." that occurs
on OS-X is mascarading an underling `Broken Pipe` error. The source of
the issue was that the connection is beeing closed prematurely
(sometimes). This is a timing issue and hence the different behavior
when re-running the command or using bundler or not.

The patch blocks until the child sends a confirmation message that
everything is established. This confirmation message must also be sent
when the rails application can't be booted.

This is a fix for the problem discussed in #2
