### PR TITLE
display a help message when no command is passed

### DIFF
--- a/lib/spring.rb
+++ b/lib/spring.rb
@@ -51,6 +51,32 @@ class Spring
   end
 
   def run(args)
+    if self.class.command_registered?(args.first)
+      run_command(args)
+    else
+      print_help
+    end
+  end
+
+  private
+
+  def print_help
+    puts <<-EOT
+Usage: spring COMMAND [ARGS]
+
+The most common spring commands are:
+ rake        Run a rake task
+ console     Start the Rails console
+ runner      Execute a command with the Rails runner
+ generate    Trigger a Rails generator
+
+ test        Execute a Test::Unit test
+ rspec       Execute an RSpec spec
+EOT
+    false
+  end
+
+  def run_command(args)
     boot_server unless server_running?
 
     application, client = UNIXSocket.pair
@@ -90,8 +116,6 @@ class Spring
     application.close if application
     server.close if server
   end
-
-  private
 
   def rails_env_for(command_name)
     command = Spring.command(command_name)

--- a/lib/spring/commands.rb
+++ b/lib/spring/commands.rb
@@ -9,6 +9,10 @@ class Spring
     commands[name] = klass.new
   end
 
+  def self.command_registered?(name)
+    commands.has_key?(name)
+  end
+
   def self.command(name)
     commands.fetch name
   end

--- a/test/acceptance/app_test.rb
+++ b/test/acceptance/app_test.rb
@@ -122,6 +122,10 @@ class AppTest < ActiveSupport::TestCase
     assert_speedup
   end
 
+  test "help message when called without arguments" do
+    assert_stdout BINFILE, 'Usage: spring COMMAND [ARGS]'
+  end
+
   test "test changes are picked up" do
     assert_successful_run test_command
 


### PR DESCRIPTION
This is a very basic implementation to prevent the error in #8. The implementation is more bolted on than integrated into the current design. I think we need to have a concept of "client commands" and "application commands". Some need to run in the rails environment and some are just to interact with spring directly. Another example for a client command are the status/start/stop operations described in #9
