### PR TITLE
Environment variable to use a custom tmp directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,3 +210,10 @@ Runs a Rails generator.
 ### `runner`
 
 The Rails runner.
+
+## Configuration
+
+### tmp directory
+
+Spring needs a tmp directory. This will default to `Rails.root + 'tmp' + 'spring'`.
+You can set your own configuration directory by setting the `SPRING_TMP_PATH` environment variable.

--- a/lib/spring/env.rb
+++ b/lib/spring/env.rb
@@ -13,7 +13,7 @@ class Spring
     end
 
     def tmp_path
-      path = root.join('tmp/spring')
+      path = default_tmp_path
       FileUtils.mkdir_p(path) unless path.exist?
       path
     end
@@ -28,6 +28,16 @@ class Spring
 
     def pidfile_path
       tmp_path.join("#{SID.sid}.pid")
+    end
+
+    private
+
+    def default_tmp_path
+      if ENV['SPRING_TMP_PATH']
+        Pathname.new(ENV['SPRING_TMP_PATH'])
+      else
+        root.join('tmp/spring')
+      end
     end
   end
 end


### PR DESCRIPTION
This patch allows you to customize the tmp directory using an environment variable. This will solve #26. I think in the long run we should aim for a configuration file in place of environment variables, so that you can set everything on a per-project basis.

I added a new section to the README about configuration.
