### PR TITLE
Provide a configuration option to set the rails root

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,19 @@ The Rails runner.
 
 ## Configuration
 
+### application_root
+
+Spring must know how to find your rails application. If you have a
+normal app everything works out of the box. If you are working on a
+project with a special setup (an engine for example), you must tell
+Spring where your app is located:
+
+**config/spring.rb**
+
+```ruby
+Spring.application_root = './test/dummy'
+```
+
 ### tmp directory
 
 Spring needs a tmp directory. This will default to `Rails.root + 'tmp' + 'spring'`.

--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -1,3 +1,4 @@
+require "spring/configuration"
 require "spring/application_watcher"
 require "spring/commands"
 require "set"
@@ -27,7 +28,8 @@ module Spring
     end
 
     def start
-      require "./config/application"
+
+      require Spring.application_root_path.join("config", "application")
 
       # The test environment has config.cache_classes = true set by default.
       # However, we don't want this to prevent us from performing class reloading,
@@ -36,7 +38,7 @@ module Spring
         ActiveSupport::Dependencies.mechanism = :load
       end
 
-      require "./config/environment"
+      require Spring.application_root_path.join("config", "environment")
 
       watcher.add_files $LOADED_FEATURES
       watcher.add_files ["Gemfile", "Gemfile.lock"].map { |f| "#{Rails.root}/#{f}" }

--- a/lib/spring/client.rb
+++ b/lib/spring/client.rb
@@ -1,3 +1,4 @@
+require "spring/configuration"
 require "spring/client/command"
 require "spring/client/run"
 require "spring/client/help"

--- a/lib/spring/configuration.rb
+++ b/lib/spring/configuration.rb
@@ -1,0 +1,11 @@
+module Spring
+  class << self
+    attr_accessor :application_root
+
+    def application_root_path
+      Pathname.new(File.expand_path(application_root))
+    end
+  end
+  self.application_root = '.'
+
+end


### PR DESCRIPTION
This will solve #36 by providing an option to configure the rails root:

**./config/spring.rb**

``` ruby
Spring.application_root = './spec/dummy'
```
