### PR TITLE
ignore test application gem files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+test/apps/rails-3-2/vendor/gems/*


### PR DESCRIPTION
When executing the tests the working directory is "dirty" because of the generated files in the test application. I think we can simply ignore them.
