### PR TITLE
the watcher is stale when a file is removed

### DIFF
--- a/lib/spring/application_watcher.rb
+++ b/lib/spring/application_watcher.rb
@@ -31,6 +31,9 @@ module Spring
 
     def compute_mtime
       expanded_files.map { |f| File.mtime(f).to_f }.max || 0
+    rescue Errno::ENOENT
+      # if a file does no longer exist, the watcher is always stale.
+      Float::MAX
     end
 
     def expanded_files

--- a/test/unit/application_watcher_test.rb
+++ b/test/unit/application_watcher_test.rb
@@ -31,6 +31,18 @@ class ApplicationWatcherTest < Test::Unit::TestCase
     assert watcher.stale?
   end
 
+  def test_tolerates_enoent
+    file = "#{@dir}/omg"
+    touch file
+
+    watcher = Spring::ApplicationWatcher.new
+    watcher.add_files [file]
+
+    assert !watcher.stale?
+    FileUtils.rm(file)
+    assert watcher.stale?
+  end
+
   def test_glob
     FileUtils.mkdir("#{@dir}/1")
     FileUtils.mkdir("#{@dir}/2")


### PR DESCRIPTION
This is a fix for #18.

I marked the watcher as stale whenever a tracked file is not found anymore. This will force the application to reboot and load the new setting instead of crashing with an `ENOENT` error.
