### PR TITLE
configure what files will be preloaded

### DIFF
--- a/test/unit/commands_test.rb
+++ b/test/unit/commands_test.rb
@@ -17,4 +17,18 @@ class CommandsTest < ActiveSupport::TestCase
     end
   end
 
+  test "prints error message when preloaded file does not exist" do
+    begin
+      original_stderr = $stderr
+      $stderr = StringIO.new('')
+      my_command_class = Class.new(Spring::Commands::Command)
+      my_command_class.preloads = %w(i_do_not_exist)
+
+      my_command_class.new.setup
+      assert_match /The #<Class:0x[0-9a-f]+> command tried to preload i_do_not_exist but could not find it./, $stderr.string
+    ensure
+      $stderr = original_stderr
+    end
+  end
+
 end


### PR DESCRIPTION
We have a custom rspec setup and don't rely on a global `spec/spec_helper.rb`.
With the current implementation of the RSpec command we can't run our specs.

Even when we can't preload the `spec_helper` it would still be an enourmous
advantage to preload the rails-stack when running our tests.

I modified the RSpec command to check if the spec_helper exists and to require
only `rspec` otherwise. While this is not an optimal solution it sill yields a
huge performance benefit in our app:

**first execution**

```
my_app :: (spring*) » time spring rspec spec/functional

Finished in 3.63 seconds
33 examples, 0 failures
bin/spring rspec spec/functional  0,64s user 0,07s system 4% cpu 14,267 total
```

**second execution**

```
my_app :: (spring*) » time spring rspec spec/functional

Finished in 3.6 seconds
33 examples, 0 failures
bin/spring rspec spec/functional  0,63s user 0,07s system 12% cpu 5,434 total
```
### Per Command Preloadable Files

The current implementation features functionality to specify what files to preload for every spring command. I kept "test_helper" and "spec_helper" as defaults but you can configure everything in your `config/spring.rb`.
