### PR TITLE
detect project and rails root

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -28,7 +28,6 @@ module Spring
     end
 
     def start
-
       require Spring.application_root_path.join("config", "application")
 
       # The test environment has config.cache_classes = true set by default.

--- a/lib/spring/client.rb
+++ b/lib/spring/client.rb
@@ -12,7 +12,11 @@ module Spring
     }
 
     def self.run(args)
+      Spring.verify_environment!
       command_for(args.first).call(args)
+    rescue InvalidEnvironmentError => e
+      STDERR.puts e
+      exit 1
     end
 
     def self.command_for(name)

--- a/lib/spring/configuration.rb
+++ b/lib/spring/configuration.rb
@@ -1,11 +1,39 @@
+require "spring/errors"
+
 module Spring
   class << self
     attr_accessor :application_root
 
+    def verify_environment!
+      application_root_path
+    end
+
     def application_root_path
-      Pathname.new(File.expand_path(application_root))
+      return @application_root_path if defined?(@application_root_path)
+      path = application_root || detect_application_root
+      @application_root_path = Pathname.new(File.expand_path(path))
+    end
+
+    private
+
+    def detect_application_root
+      project_root = detect_project_root
+      if File.exist?(project_root.join "config", "application.rb")
+        project_root
+      else
+        raise MissingApplicationRoot.new(Dir.pwd, project_root)
+      end
+    end
+
+    def detect_project_root(current_dir = Pathname.new(Dir.pwd))
+      if File.exist?(current_dir.join "Gemfile")
+        current_dir
+      elsif current_dir.root?
+        raise MissingProjectRootError.new(Dir.pwd)
+      else
+        detect_project_root(current_dir.parent)
+      end
     end
   end
-  self.application_root = '.'
 
 end

--- a/lib/spring/errors.rb
+++ b/lib/spring/errors.rb
@@ -1,0 +1,31 @@
+module Spring
+  class InvalidEnvironmentError < StandardError; end
+
+  class MissingProjectRootError < InvalidEnvironmentError
+    def initialize(curent_dir)
+      super <<-MSG
+Spring was not able to locate the root of your project.
+You should:
+  - make sure that you are inside a rails application.
+
+Spring used the following paths to detect the project root (`Gemfile`):
+  pwd: #{current_dir}
+MSG
+    end
+  end
+
+  class MissingApplicationRoot < InvalidEnvironmentError
+    def initialize(current_dir, project_root)
+      super <<-MSG
+Spring was not able to locate the rails root of your project.
+You should:
+  - change your woring directory.
+  - configure the location of your rails application using `config/spring.rb`.
+
+Spring used the following paths to detect the Rails root (`config/application.rb`):
+  pwd: #{current_dir}
+  project root: #{project_root}
+MSG
+    end
+  end
+end


### PR DESCRIPTION
This is a first stab at implementing the project/rails root detection with proper error messages. It works but when the project or rails root can't be detected spring crashes. I wanted to show you the current implementation to start a discussion.

Currently if the rails root can't be detected it fails like:

```
          Spring was not able to locate the rails root of your project. You should:
            - change your woring directory.
            - configure the location of your rails application using `config/spring.rb`.

          Spring used the following paths to detect the Rails root (`config/application.rb`):
            pwd: /Users/senny/Projects/spring/test/apps
            project root: /Users/senny/Projects/spring
/Users/senny/Projects/spring/lib/spring/application_manager.rb:53:in `run': undefined method `chomp' for nil:NilClass (NoMethodError)
    from /Users/senny/Projects/spring/lib/spring/server.rb:39:in `serve'
    from /Users/senny/Projects/spring/lib/spring/server.rb:31:in `block in boot'
    from /Users/senny/Projects/spring/lib/spring/server.rb:31:in `loop'
    from /Users/senny/Projects/spring/lib/spring/server.rb:31:in `boot'
    from /Users/senny/Projects/spring/lib/spring/server.rb:9:in `boot'
    from -e:1:in `<main>'
/Users/senny/Projects/spring/lib/spring/client/run.rb:56:in `call': undefined method `chomp' for nil:NilClass (NoMethodError)
    from /Users/senny/Projects/spring/lib/spring/client/command.rb:7:in `call'
    from /Users/senny/Projects/spring/lib/spring/client.rb:15:in `run'
    from ../../bin/spring:4:in `<main>'
```
