### PR TITLE
basic support for after_fork callbacks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,22 @@ Commands::Command::RSpec.preloads = []
 Commands::Command::Console.preloads << 'extenstions/console_helper'
 ```
 
+### after fork callbacks
+
+You might want to run code after Spring forked off the process but
+before the actual command is run. You might want to use an
+`after_fork` callback if you have to connect to an external service,
+do some general cleanup or set up dynamic configuration.
+
+```ruby
+Spring.after_fork do
+  # run arbitrary code
+end
+```
+
+If you want to register multiple callbacks you can simply call
+`Spring.after_fork` multiple times with different blocks.
+
 ### tmp directory
 
 Spring needs a tmp directory. This will default to `Rails.root.join('tmp', 'spring')`.

--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -68,6 +68,7 @@ module Spring
         Process.setsid
         [STDOUT, STDERR, STDIN].zip(streams).each { |a, b| a.reopen(b) }
         IGNORE_SIGNALS.each { |sig| trap(sig, "DEFAULT") }
+        invoke_after_fork_callbacks
         command.call(args)
       }
 
@@ -92,6 +93,12 @@ module Spring
       if command.respond_to?(:setup)
         command.setup
         watcher.add_files $LOADED_FEATURES # loaded features may have changed
+      end
+    end
+
+    def invoke_after_fork_callbacks
+      Spring.after_fork_callbacks.each do |callback|
+        callback.call
       end
     end
   end

--- a/lib/spring/configuration.rb
+++ b/lib/spring/configuration.rb
@@ -4,6 +4,14 @@ module Spring
   class << self
     attr_accessor :application_root
 
+    def after_fork_callbacks
+      @after_fork_callbacks ||= []
+    end
+
+    def after_fork(&block)
+      after_fork_callbacks << block
+    end
+
     def verify_environment!
       application_root_path
     end

--- a/test/acceptance/app_test.rb
+++ b/test/acceptance/app_test.rb
@@ -264,6 +264,18 @@ class AppTest < ActiveSupport::TestCase
     assert_stdout "bin/rake -T", "rake db:migrate"
   end
 
+  test "after fork callback" do
+    begin
+      config_path = "#{app_root}/config/spring.rb"
+      config_contents = File.read(config_path)
+
+      File.write(config_path, config_contents + "\nSpring.after_fork { puts '!callback!' }")
+      assert_stdout "spring r 'puts 2'", "!callback!\n2"
+    ensure
+      File.write(config_path, config_contents)
+    end
+  end
+
   test "missing config/application.rb" do
     begin
       FileUtils.mv app_root.join("config/application.rb"), app_root.join("config/application.rb.bak")


### PR DESCRIPTION
this is a very basic implementation for #16. I currently only implemented global `after_fork` callbacks. The functionality is completely separated from the commands. Some thoughts:
- We could put `invoke_after_fork_callbacks` on the `Command` class
- We could have a simple method on `Command` to first invoke the callbacks and then call it.

``` ruby
class Command
  def run(args)
    invoke_after_fork_callbacks
    call(args)
  end
end
```

This would give the commands more flexibility over the execution process.

The current implementation is very straight forward and should serve as a point to start a discussion.
