### PR TITLE
conditionalize to avoid deprecation in 2.0.0

### DIFF
--- a/lib/spring/sid.rb
+++ b/lib/spring/sid.rb
@@ -2,8 +2,14 @@ require 'fiddle'
 
 module Spring
   module SID
+    if RUBY_VERSION >= '2.0.0'
+      handle = Fiddle::Handle
+    else
+      handle = DL::Handle
+    end
+
     FUNC = Fiddle::Function.new(
-      DL::Handle::DEFAULT['getsid'],
+      handle::DEFAULT['getsid'],
       [Fiddle::TYPE_INT],
       Fiddle::TYPE_INT
     )


### PR DESCRIPTION
If you don't require `dl` in ruby 2.0.0, then the DL constant is not available.  This should fix it.
