### PR TITLE
Don't depend on active support

### DIFF
--- a/lib/spring/commands.rb
+++ b/lib/spring/commands.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/class/attribute'
-
 module Spring
   @commands = {}
 
@@ -25,8 +23,32 @@ module Spring
 
   module Commands
     class Command
-      class_attribute :preloads
-      self.preloads = []
+      @preloads = []
+
+      class << self
+        attr_accessor :preloads
+
+        def inherited(c)
+          c.class_eval do
+            @preloads = []
+
+            class << self
+              def preloads
+                Command.preloads + @preloads
+              end
+
+              def preloads=(files)
+                @preloads = files
+              end
+            end
+
+            def preloads
+              self.class.preloads
+            end
+          end
+        end
+      end
+
 
       def setup
         preload_files
@@ -167,5 +189,4 @@ MESSAGE
   # needs to be at the end to allow modification of existing commands.
   config = File.expand_path("./config/spring.rb")
   require config if File.exist?(config)
-
 end

--- a/test/unit/commands_test.rb
+++ b/test/unit/commands_test.rb
@@ -2,7 +2,6 @@ require "helper"
 require "spring/commands"
 
 class CommandsTest < ActiveSupport::TestCase
-
   test "test command needs a test name" do
     begin
       real_stderr = $stderr
@@ -15,6 +14,19 @@ class CommandsTest < ActiveSupport::TestCase
     ensure
       $stderr = real_stderr
     end
+  end
+
+  test 'children of Command have inheritable accessor named "preload"' do
+    assert_equal [], Spring::Commands::Command.preloads
+
+    my_command_class = Class.new(Spring::Commands::Command)
+    my_command_class.preloads += %w(baz)
+    assert_equal [], Spring::Commands::Command.preloads
+    assert_equal %w(baz), my_command_class.preloads
+
+    Spring::Commands::Command.preloads = %w(foo bar)
+    assert_equal %w(foo bar), Spring::Commands::Command.preloads
+    assert_equal %w(foo bar baz), my_command_class.preloads
   end
 
   test "prints error message when preloaded file does not exist" do
@@ -30,5 +42,4 @@ class CommandsTest < ActiveSupport::TestCase
       $stderr = original_stderr
     end
   end
-
 end


### PR DESCRIPTION
Running spring command failed on my edge Rails app with this error:

> You have already activated activesupport 3.2.12, but your Gemfile requires activesupport 4.0.0.beta.

So I reinvented the AS `class_attribute`. Fixes #52.
