### PR TITLE
Teach commands to parse Rails env from command-line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,13 @@ Boots into the Rails console. Currently this is usable but not perfect,
 for example you can't scroll back through command history. (That will be
 fixed.)
 
+You can pass the Rails env as argument, just like you would to `rails console`,
+e.g.:
+
+```
+$ spring console test
+```
+
 ### `generate`
 
 Runs a Rails generator.
@@ -253,6 +260,13 @@ Runs a Rails generator.
 ### `runner`
 
 The Rails runner.
+
+You can pass the Rails env as argument, just like you would to `rails runner`
+using the `-e` or `--environment` options, e.g.:
+
+```
+$ spring runner -e test 'puts Rails.env'
+```
 
 ## Configuration
 

--- a/lib/spring/client/run.rb
+++ b/lib/spring/client/run.rb
@@ -26,7 +26,7 @@ module Spring
 
         verify_server_version(server)
         server.send_io client
-        server.puts rails_env_for(args.first)
+        server.puts rails_env_for(*args)
 
         application.send_io STDOUT
         application.send_io STDERR
@@ -79,14 +79,14 @@ ERROR
         end
       end
 
-      def rails_env_for(command_name)
+      def rails_env_for(command_name, *tail)
         command = Spring.command(command_name)
 
         if command.respond_to?(:env)
-          command.env
-        else
-          ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
+          env = command.env(tail)
         end
+
+        env || ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
       end
 
       def forward_signals(pid)

--- a/lib/spring/commands.rb
+++ b/lib/spring/commands.rb
@@ -61,7 +61,7 @@ MESSAGE
     class Test < Command
       preloads << "test_helper"
 
-      def env
+      def env(*)
         "test"
       end
 
@@ -94,7 +94,7 @@ MESSAGE
     class RSpec < Command
       preloads << "spec_helper"
 
-      def env
+      def env(*)
         "test"
       end
 
@@ -116,7 +116,7 @@ MESSAGE
     Spring.register_command "rspec", RSpec.new
 
     class Cucumber < Command
-      def env
+      def env(*)
         "test"
       end
 
@@ -154,6 +154,10 @@ MESSAGE
 
 
     class Console < Command
+      def env(tail)
+        tail.first if tail.first && !tail.first.index("-")
+      end
+
       def setup
         require "rails/commands/console"
       end
@@ -187,6 +191,18 @@ MESSAGE
     Spring.register_command "generate", Generate.new, alias: "g"
 
     class Runner < Command
+      def env(tail)
+        previous_option = nil
+        tail.reverse.each do |option|
+          case option
+          when /--environment=(\w+)/ then return $1
+          when '-e' then return previous_option
+          end
+          previous_option = option
+        end
+        nil
+      end
+
       def call(args)
         Object.const_set(:APP_PATH, Rails.root.join('config/application'))
         ARGV.replace args

--- a/test/acceptance/app_test.rb
+++ b/test/acceptance/app_test.rb
@@ -281,4 +281,10 @@ class AppTest < ActiveSupport::TestCase
     app_run "#{spring} runner ''"
     assert_success "#{spring} status", stdout: "Spring is running"
   end
+
+  test "runner command sets Rails environment from command-line options" do
+    # Not using "test" environment here to avoid false positives on Travis (where "test" is default)
+    assert_success "#{spring} runner -e staging 'puts Rails.env'", stdout: "staging"
+    assert_success "#{spring} runner --environment=staging 'puts Rails.env'", stdout: "staging"
+  end
 end

--- a/test/unit/commands_test.rb
+++ b/test/unit/commands_test.rb
@@ -50,4 +50,29 @@ class CommandsTest < ActiveSupport::TestCase
       $stderr = original_stderr
     end
   end
+
+  test 'console command sets rails environment from command-line option' do
+    command = Spring::Commands::Console.new
+    assert_equal 'test', command.env(['test'])
+  end
+
+  test 'console command ignores first argument if it is a flag' do
+    command = Spring::Commands::Console.new
+    assert_nil command.env(['--sandbox'])
+  end
+
+  test 'Runner#env sets rails environment from command-line option' do
+    command = Spring::Commands::Runner.new
+    assert_equal 'test', command.env(['-e', 'test', 'puts 1+1'])
+  end
+
+  test 'Runner#env sets rails environment from long form of command-line option' do
+    command = Spring::Commands::Runner.new
+    assert_equal 'test', command.env(['--environment=test', 'puts 1+1'])
+  end
+
+  test 'Runner#env ignores insignificant arguments' do
+    command = Spring::Commands::Runner.new
+    assert_nil command.env(['puts 1+1'])
+  end
 end


### PR DESCRIPTION
Some commands (e.g. `runner` or `console`) allow users to specify the
Rails env (e.g. `rails runner -e test` or `rails console test`). This
commit parses options passed to `spring (runner|console)`, using some
poor man's `optparse`.

Before - this would be the buggy behaviour:

```
$ spring runner -e test puts\ Rails.env
development
```

After - spring parses the `-e` option:

```
$ spring runner -e test puts\ Rails.env
test
```

Supported options are:
- runner -e some_env
- runner --environment=some_env
- console some_env

A side effect of this change is that `Command#env` may now return `nil`,
in which case `#rails_env_for` will fallback to RAILS_ENV, etc.
