### PR TITLE
Document RSpec troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,3 +322,12 @@ If you want to register multiple callbacks you can simply call
 
 Spring needs a tmp directory. This will default to `Rails.root.join('tmp', 'spring')`.
 You can set your own configuration directory by setting the `SPRING_TMP_PATH` environment variable.
+
+## Troubleshooting
+
+### RSpec
+
+1. Remove the `require 'rspec/autorun'` line.
+2. Force `RAILS_ENV` to be set to `test` (`ENV['RAILS_ENV'] = 'test'`)
+   instead of `||=`; `RAILS_ENV` will already be assigned to
+   `development`, meaning the proper gems will not be loaded.


### PR DESCRIPTION
These two steps make `spring rake` and `spring rspec` significantly more
likely to work.

`spring rake` needs RAILS_ENV to be set to test; otherwise, gems are not
loaded appropriately.

`spring rspec` needs rspec/autorun not to be loaded.
