### PR TITLE
Close database connection in Application process.

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -68,6 +68,7 @@ module Spring
         Process.setsid
         [STDOUT, STDERR, STDIN].zip(streams).each { |a, b| a.reopen(b) }
         IGNORE_SIGNALS.each { |sig| trap(sig, "DEFAULT") }
+        ActiveRecord::Base.establish_connection if defined?(ActiveRecord::Base)
         invoke_after_fork_callbacks
         command.call(args)
       }
@@ -103,6 +104,8 @@ module Spring
         command.setup
         watcher.add_files $LOADED_FEATURES # loaded features may have changed
       end
+
+      ActiveRecord::Base.connection.disconnect! if defined?(ActiveRecord::Base)
     end
 
     def invoke_after_fork_callbacks

--- a/test/acceptance/app_test.rb
+++ b/test/acceptance/app_test.rb
@@ -284,7 +284,7 @@ class AppTest < ActiveSupport::TestCase
 
   test "runner command sets Rails environment from command-line options" do
     # Not using "test" environment here to avoid false positives on Travis (where "test" is default)
-    assert_success "#{spring} runner -e staging 'puts Rails.env'", stdout: "staging"
-    assert_success "#{spring} runner --environment=staging 'puts Rails.env'", stdout: "staging"
+    assert_success "#{spring} runner -e development 'puts Rails.env'", stdout: "development"
+    assert_success "#{spring} runner --environment=development 'puts Rails.env'", stdout: "development"
   end
 end


### PR DESCRIPTION
Addresses issue #73.  

I had to change the acceptance test's `runner command sets Rails environment from command-line options` test to use `development` instead of `staging` because there is no `staging` environment configuration in our test app.
