### PR TITLE
Disable autorun when running RSpec

### DIFF
--- a/lib/spring/commands.rb
+++ b/lib/spring/commands.rb
@@ -104,8 +104,9 @@ MESSAGE
 
       def setup
         $LOAD_PATH.unshift "spec"
-        super
         require 'rspec/core'
+        ::RSpec::Core::Runner.disable_autorun!
+        super
       end
 
       def call(args)


### PR DESCRIPTION
N.B. This pull request doesn't contain any tests.  I couldn't see 
any for the rspec command, but would be happy to add one if
pointed in the right direction.

Current versions of rspec-rails generate a spec_helper.rb file that
requires 'rspec/autorun'.  This allows individual specs to be run
using `ruby -Ispec path/to/spec`, but causes the spring `rspec`
command to run specs twice.  Disabling autorun before requiring
preloaded files (which will normally include spec_helper) prevents
this.
