### PR TITLE
make "spring test" support multiple arguments

### DIFF
--- a/lib/spring/commands.rb
+++ b/lib/spring/commands.rb
@@ -77,12 +77,14 @@ MESSAGE
       def call(args)
         if args.size > 0
           ARGV.replace args
-          path = File.expand_path(args.first)
+          args.each do |arg|
+            path = File.expand_path(arg)
 
-          if File.directory?(path)
-            Dir[File.join path, "**", "*_test.rb"].each { |f| require f }
-          else
-            require path
+            if File.directory?(path)
+              Dir[File.join path, "**", "*_test.rb"].each { |f| require f }
+            else
+              require path
+            end
           end
         else
           $stderr.puts "you need to specify what test to run: spring test TEST_NAME"


### PR DESCRIPTION
"spring test" needs to accept multiple arguments if guard-minitest is to ever have a chance of supporting spring.
