### PR TITLE
Load watcher before printing help. Fixes #131.

### DIFF
--- a/lib/spring/client/help.rb
+++ b/lib/spring/client/help.rb
@@ -10,6 +10,7 @@ module Spring
       end
 
       def self.call(args)
+        require "spring/watcher"
         require "spring/commands"
         super
       end


### PR DESCRIPTION
Currently, having the following in your `config/spring.rb` (as suggested in the [README](https://github.com/jonleighton/spring#watching-files-and-directories)) will cause an error when running `spring help`:

``` ruby
Spring.watch "spec/factories"
```

This pull request fixes that error.
