### PR TITLE
Make ListenWatcher optional. Closes #128

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,3 +351,17 @@ end
 ```
 
 Note that this make the initial application startup slightly slower.
+
+### Watchers
+
+Spring will automatically watch for changes by `:polling`, alternate watchers can be specified like `:listen`.
+
+```ruby
+Spring.watch_via = :polling
+```
+
+To use [listen](https://github.com/guard/listen) you will need to add the gem to your Gemfile.
+
+```ruby
+gem 'listen', group: ['development', 'test']
+```

--- a/lib/spring/watcher.rb
+++ b/lib/spring/watcher.rb
@@ -4,21 +4,32 @@ require "spring/watcher/polling"
 
 module Spring
   class << self
-    attr_accessor :watch_interval
+    attr_accessor :watch_interval, :watch_via
     attr_writer :watcher
   end
 
   self.watch_interval = 0.2
+  self.watch_via = :polling
 
   def self.watcher
     @watcher ||= watcher_class.new(Spring.application_root_path, watch_interval)
   end
 
   def self.watcher_class
-    if Watcher::Listen.available?
-      Watcher::Listen
-    else
+    if watch_via.to_s == 'listen'
+      if Watcher::Listen.available?
+        Watcher::Listen
+      else
+        puts %Q{Listen gem was not found, please add this to your Gemfile. `gem 'listen', group: ['test','development']`
+Falling back to Wather::Polling}
+        Watcher::Polling
+      end
+    elsif watch_via.to_s == 'polling'
       Watcher::Polling
+    elsif watch_via.kind_of?(Class)
+      watch_via
+    else
+      raise NotImplementedError
     end
   end
 

--- a/test/acceptance/app_test.rb
+++ b/test/acceptance/app_test.rb
@@ -233,11 +233,17 @@ class AppTest < ActiveSupport::TestCase
       gemfile = app_root.join("Gemfile")
       gemfile_contents = gemfile.read
       File.write(gemfile, gemfile_contents.sub(%{# gem 'listen'}, %{gem 'listen'}))
+
+      config_path = "#{app_root}/config/spring.rb"
+      config_contents = File.read(config_path)
+      File.write(config_path,config_contents + "\nSpring.watch_via = :listen")
+
       app_run "bundle install", timeout: nil
 
       assert_success "#{spring} rails runner 'puts Spring.watcher.class'", stdout: "Listen"
       assert_app_reloaded
     ensure
+      File.write(config_path,config_contents)
       File.write(gemfile, gemfile_contents)
       assert_success "bundle check"
     end

--- a/test/unit/watcher_test.rb
+++ b/test/unit/watcher_test.rb
@@ -141,7 +141,8 @@ class ListenWatcherTest < ActiveSupport::TestCase
   include WatcherTests
 
   def watcher_class
-    Spring::Watcher::Listen
+    Spring.watch_via = :listen
+    Spring.watcher_class
   end
 
   test "root directories" do
@@ -167,6 +168,16 @@ class PollingWatcherTest < ActiveSupport::TestCase
   include WatcherTests
 
   def watcher_class
-    Spring::Watcher::Polling
+    Spring.watch_via = :polling
+    Spring.watcher_class
+  end
+end
+
+class CustomWatcherTest < ActiveSupport::TestCase
+  class DummyListener; end
+
+  def test_watcher_class
+    Spring.watch_via = DummyListener
+    assert_equal Spring.watcher_class, DummyListener
   end
 end


### PR DESCRIPTION
Spring will automatically watch for changes by `:polling`, alternate watchers can be specified like `:listen`.

``` ruby
Spring.watch_via = :polling
```

To use [listen](https://github.com/guard/listen) you will need to add the gem to your Gemfile.

``` ruby
gem 'listen', group: ['development', 'test']
```
