### PR TITLE
Ignore bundler path

### DIFF
--- a/lib/spring/watcher/listen.rb
+++ b/lib/spring/watcher/listen.rb
@@ -21,7 +21,9 @@ module Spring
 
       def start
         unless @listener
-          @listener = listen_klass.new(*base_directories, relative_paths: false)
+          bundle_path = Bundler.bundle_path.relative_path_from(Pathname.new(root)).to_s
+          ignore = [Regexp.new("^#{Regexp.escape(bundle_path)}")]
+          @listener = listen_klass.new(*base_directories, relative_paths: false, ignore: ignore)
           @listener.latency(latency)
           @listener.change(&method(:changed))
 


### PR DESCRIPTION
When I install gems locally by `bundle install --path ./vendor/gems`, recursively walking through this directory takes long time.
In my case, this patch saves 2-3 seconds in the initial watcher setup.
