### PR TITLE
Uniquify base directories

### DIFF
--- a/lib/spring/watcher/listen.rb
+++ b/lib/spring/watcher/listen.rb
@@ -59,9 +59,10 @@ module Spring
       end
 
       def base_directories
-        [root] +
+        ([root] +
           files.reject       { |f| f.start_with? root }.map { |f| File.expand_path("#{f}/..") } +
           directories.reject { |d| d.start_with? root }
+        ).uniq
       end
     end
   end


### PR DESCRIPTION
When I manually specify watching targets by `Spring.watch` in config/spring.rb,  some duplications of paths could happen.
Removing duplications saves a few seconds, in my case.
