### PR TITLE
Handle multibyte characters in environment variables

### DIFF
--- a/lib/spring/client/run.rb
+++ b/lib/spring/client/run.rb
@@ -95,7 +95,7 @@ ERROR
       def send_json(socket, data)
         data = JSON.dump(data)
 
-        socket.puts  data.length
+        socket.puts  data.bytesize
         socket.write data
       end
     end

--- a/test/acceptance/app_test.rb
+++ b/test/acceptance/app_test.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'helper'
 require 'io/wait'
 require "timeout"
@@ -33,7 +34,7 @@ class AppTest < ActiveSupport::TestCase
   end
 
   def env
-    @env ||= {"GEM_HOME" => gem_home.to_s, "GEM_PATH" => ""}
+    @env ||= {"GEM_HOME" => gem_home.to_s, "GEM_PATH" => "", "UTF_8" => "✓"}
   end
 
   def app_run(command, opts = {})


### PR DESCRIPTION
Send byte size of JSON instead of string length as IO#read uses byte lengths. If environment contains multibyte UTF-8 characters, byte size is more than string length and read content is cropped.
