### PR TITLE
Don't error on watching non-existent files

### DIFF
--- a/lib/spring/watcher/abstract.rb
+++ b/lib/spring/watcher/abstract.rb
@@ -36,6 +36,8 @@ module Spring
           end
         end
 
+        items = items.select(&:exist?)
+
         items.each do |item|
           if item.directory?
             directories << item.realpath.to_s

--- a/test/unit/watcher_test.rb
+++ b/test/unit/watcher_test.rb
@@ -135,6 +135,11 @@ module WatcherTests
     watcher.add "./foo"
     assert_equal ["#{dir}/foo"], watcher.files.to_a
   end
+
+  def test_add_non_existant_file
+    watcher.add './foobar'
+    assert watcher.files.empty?
+  end
 end
 
 class ListenWatcherTest < ActiveSupport::TestCase


### PR DESCRIPTION
calling .realpath will throw a Errno::ENOENT, but as per pr #147,
we would rather not watch non-existent files.
