### PR TITLE
Display spring version in the help message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next release
+
+* Display spring version in the help message
+
 ## 0.0.11
 
 * Added the `rails destroy` command.

--- a/lib/spring/client/help.rb
+++ b/lib/spring/client/help.rb
@@ -28,7 +28,8 @@ module Spring
       end
 
       def formatted_help
-        ["Usage: spring COMMAND [ARGS]\n",
+        ["Version: #{env.version}\n",
+         "Usage: spring COMMAND [ARGS]\n",
          *command_help("spring itself", spring_commands),
          '',
          *command_help("your application", application_commands)].join("\n")

--- a/test/unit/client/help_test.rb
+++ b/test/unit/client/help_test.rb
@@ -41,6 +41,8 @@ class HelpTest < ActiveSupport::TestCase
 
   test "formatted_help generates expected output" do
     expected_output = <<-EOF
+Version: #{Spring::VERSION}
+
 Usage: spring COMMAND [ARGS]
 
 Commands for spring itself:


### PR DESCRIPTION
I feel it is useful to have the spring version displayed. I can change my pull request to display it in a proper `spring help` command if you prefer.

BTW thanks a lot for spring, it is immensely useful.
