### PR TITLE
'Fixed' automatic loading of commands from spring-commands-* gems

### DIFF
--- a/lib/spring/commands.rb
+++ b/lib/spring/commands.rb
@@ -19,6 +19,16 @@ module Spring
     commands.fetch name
   end
 
+  class << self
+
+    def require_commands
+      Gem::Specification.map(&:name).grep(/^spring-commands-/).each do |command|
+        require command.gsub('-', '/')
+      end
+    end
+
+  end
+
   require "spring/commands/rails"
   require "spring/commands/rake"
 
@@ -31,9 +41,7 @@ module Spring
   # then we need to be under bundler.
   require "bundler/setup"
 
-  Gem::Specification.map(&:name).grep(/^spring-commands-/).each do |command|
-    require command
-  end
+  require_commands
 
   config = File.expand_path("./config/spring.rb")
   require config if File.exist?(config)

--- a/spring.gemspec
+++ b/spring.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'activesupport'
   gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'minitest-stub_any_instance'
 end

--- a/test/unit/commands_test.rb
+++ b/test/unit/commands_test.rb
@@ -1,4 +1,5 @@
 require "helper"
+require "minitest/stub_any_instance"
 require "spring/commands"
 
 class CommandsTest < ActiveSupport::TestCase
@@ -34,4 +35,16 @@ class CommandsTest < ActiveSupport::TestCase
     assert_equal "test", command.env(["test:models"])
     assert_nil command.env(["test_foo"])
   end
+
+  test "Spring.require_commands correctly requires commands from gems" do
+    mock = MiniTest::Mock.new
+    mock.expect :call, true, ["spring/commands/rspec"]
+    Object.stub_any_instance :require, mock do
+      Gem::Specification.stub :map, ['spring-commands-rspec'] do
+        Spring.require_commands
+      end
+    end
+    mock.verify
+  end
+
 end


### PR DESCRIPTION
Clever Me™ spent time fixing this before I realised that this had actually already been fixed in spring-commands-rspec v1.0.1...

However, I figured it could be helpful having this in spring, so that command gems could just follow the convention?
