### PR TITLE
Add -v and --version commands for returning the version.

### DIFF
--- a/lib/spring/client.rb
+++ b/lib/spring/client.rb
@@ -8,15 +8,18 @@ require "spring/client/binstub"
 require "spring/client/stop"
 require "spring/client/status"
 require "spring/client/rails"
+require "spring/client/version"
 
 module Spring
   module Client
     COMMANDS = {
-      "help"    => Client::Help,
-      "binstub" => Client::Binstub,
-      "stop"    => Client::Stop,
-      "status"  => Client::Status,
-      "rails"   => Client::Rails
+      "help"      => Client::Help,
+      "binstub"   => Client::Binstub,
+      "stop"      => Client::Stop,
+      "status"    => Client::Status,
+      "rails"     => Client::Rails,
+      "-v"        => Client::Version,
+      "--version" => Client::Version
     }
 
     def self.run(args)

--- a/lib/spring/client/version.rb
+++ b/lib/spring/client/version.rb
@@ -1,0 +1,11 @@
+require "spring/version"
+
+module Spring
+  module Client
+    class Version < Command
+      def call
+        puts "Spring version #{Spring::VERSION}"
+      end
+    end
+  end
+end

--- a/test/unit/client/version_test.rb
+++ b/test/unit/client/version_test.rb
@@ -1,0 +1,14 @@
+require 'helper'
+require 'spring/client'
+
+class VersionTest < ActiveSupport::TestCase
+  test "outputs current version number" do
+    version = Spring::Client::Version.new 'version'
+
+    out, err = capture_io do
+      version.call
+    end
+
+    assert_equal "Spring version #{Spring::VERSION}", out.chomp
+  end
+end


### PR DESCRIPTION
While writing the tests I realised that the version is made available through `spring help` but the unix default (and more intuitive) place for this is `-v` and `--version`.

The implementation reuses the existing `Client::COMMANDS` map which works but doesn't feel great. I didn't want to introduce option parser or thor without first providing the simplest solution.
