### PR TITLE
Open pidfile in 'r+' mode on illumos or solaris based platforms.

### DIFF
--- a/lib/spring/env.rb
+++ b/lib/spring/env.rb
@@ -60,7 +60,7 @@ module Spring
     end
 
     def server_running?
-      pidfile = pidfile_path.open('r')
+      pidfile = pidfile_path.open('r+')
       !pidfile.flock(File::LOCK_EX | File::LOCK_NB)
     rescue Errno::ENOENT
       false


### PR DESCRIPTION
On SmartOS joyent_20131213T023304Z running `spring status` or any other spring commands results in a `Errno::EBADF` being thrown due to a difference in how illumos based systems handle `flock(2)`.

Here's an example stack trace from version 1.0.0 (spring from master results in the same error):

```
$ spring status
~/.rbenv/versions/2.0.0-p353/gemsets/global/gems/spring-1.0.0/lib/spring/env.rb:64:in `flock': Bad file number - /tmp/spring/f72abd9b5a9b90f5ff53a68078be2b0d.pid (Errno::EBADF)
    from ~/.rbenv/versions/2.0.0-p353/gemsets/global/gems/spring-1.0.0/lib/spring/env.rb:64:in `server_running?'
    from ~/.rbenv/versions/2.0.0-p353/gemsets/global/gems/spring-1.0.0/lib/spring/client/status.rb:9:in `call'
    from ~/.rbenv/versions/2.0.0-p353/gemsets/global/gems/spring-1.0.0/lib/spring/client/command.rb:7:in `call'
    from ~/.rbenv/versions/2.0.0-p353/gemsets/global/gems/spring-1.0.0/lib/spring/client.rb:23:in `run'
    from ~/.rbenv/versions/2.0.0-p353/gemsets/global/gems/spring-1.0.0/bin/spring:31:in `<top (required)>'
    from spring:12:in `load'
    from spring:12:in `<main>'
```
### Short Version

illumos based platforms require write permission on a file descriptor when performing an exclusive lock `File::LOCK_EX`.  This pull request uses `RUBY_PLATFORM` to detect solaris based platforms and opens the pidfile in `r+` mode instead of `r`.
### Long Version

From [flock(3ucb)](http://illumos.org/man/3ucb/flock):

> Read permission is required on a file  to  obtain  a  shared
> lock,   and  write  permission  is  required  to  obtain  an
> exclusive lock. Locking a segment that is already locked  by
> the  calling  process causes the old lock type to be removed
> and the new lock type to take effect.

A quick glance around at darwin [flock(2)](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/flock.2.html) and linux [flock(2)](http://linux.die.net/man/2/flock) don't show any such restriction like the one in illumos.

Thanks!
