### PR TITLE
Fix undefined method .path on nil

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -102,7 +102,7 @@ module Spring
       watcher.add loaded_application_features
       watcher.add Spring.gemfile, "#{Spring.gemfile}.lock"
 
-      if defined?(Rails) and Rails.application
+      if defined?(Rails) && Rails.application
         watcher.add Rails.application.paths["config/initializers"]
         watcher.add Rails.application.paths["config/database"]
       end


### PR DESCRIPTION
Hi,

I got a undefined method call on .nil at line 106 of spring/application.rb.
After deeper investigation I've found out that my Gemfile didn't have sinatra, but other gem required it.
That caused spring to fail loading of rails app and crash.

This simple change checks that Rails.application is there before accessing it.

With this change it raises proper message that required file is not there.
