### PR TITLE
Assign envs before preload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next Version
 
+* Ensure an application is started with the correct ENV - @eval
 * Accept -e and --environment options for `rails console`.
 * Watch `config/secrets.yml` by default. #289 - @morgoth
 * Custom Spring commands that implement `#binstub_prelude` will have that

--- a/test/acceptance/app_test.rb
+++ b/test/acceptance/app_test.rb
@@ -291,6 +291,18 @@ CODE
     assert_success "bin/rake -p 'Rails.env'", stdout: "test"
   end
 
+  test "config via environment variable" do
+    File.write(app.path('config/initializers/set_foo.rb'), <<-CONFIG)
+      Rails.application.config.foo = !!ENV['FOO']
+    CONFIG
+
+    app.env['FOO'] = '1'
+    assert_success "bin/rails runner -e test 'p Rails.application.config.foo'", stdout: "true"
+
+    app.env['FOO'] = nil
+    assert_success "bin/rails runner -e development 'p Rails.application.config.foo'", stdout: "false"
+  end
+
   test "setting env vars with rake" do
     File.write(app.path("lib/tasks/env.rake"), <<-'CODE')
       task :print_rails_env => :environment do


### PR DESCRIPTION
Currently ENV's of the client are not up to date during initialization of the app.

When having the following in `config/application.rb`

``` ruby
...
    config.force_ssl = !!ENV['FORCE_SSL']
...
```

The following occurs:
1) `FORCE_SSL=1 RAILS_ENV=test bin/rails runner 'p Rails.application.config.force_ssl' # => true`
2) `RAILS_ENV=development bin/rails runner 'p Rails.application.config.force_ssl' # => true`

If you reverse these steps, the result for both steps would be `false`.

Obviously we want 1 to yield true, and 2 to yield false.
