### PR TITLE
Move spring gem into bundler `tools` group

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ provide a speed up on platforms which don't support forking (Windows, JRuby).
 Add spring to your Gemfile:
 
 ``` ruby
-gem "spring", group: :development
+gem "spring", group: :tools
 ```
 
 It's recommended to 'springify' the executables in your `bin/`


### PR DESCRIPTION
It's just a change a documentation, but I don't know why everyone puts gems like `spring`, `capistrano`, `zeus` into a development group. They don't need to be required by bundler in a default development env. So I like to use a `tools` group which tells that gem is important, but not require it in any is environment.
