### PR TITLE
Add support for a .spring.rb in the project root that always gets loaded early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 * The `rails runner` command no longer passes environment switches to
   files which it runs. Issue #272.
 
+* Add support for a `.spring.rb` config file in the project root that
+  is loaded before calling the spring `Command`, so it's a good place to
+  modify spring for your own unique needs.
+
 ## 1.1.2
 
 * Detect old binstubs generated with Spring 1.0 and exit with an error.

--- a/bin/spring
+++ b/bin/spring
@@ -45,4 +45,7 @@ end
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require 'spring/client'
+Spring.project_root_path.join('.spring.rb').tap do |config|
+  require config if config.exist?
+end
 Spring::Client.run(ARGV)

--- a/lib/spring/application/boot.rb
+++ b/lib/spring/application/boot.rb
@@ -2,6 +2,9 @@
 Process.setsid
 
 require "spring/application"
+Spring.project_root_path.join('.spring.rb').tap do |config|
+  require config if config.exist?
+end
 
 app = Spring::Application.new(
   UNIXSocket.for_fd(3),

--- a/test/acceptance/app_test.rb
+++ b/test/acceptance/app_test.rb
@@ -247,6 +247,12 @@ CODE
     assert_success "bin/rails runner 'puts 2'", stdout: "!callback!\n2"
   end
 
+  test "project_root config file evaluated" do
+    File.write(app.project_root_spring_config, "Spring.after_fork { puts '!callback!' }\n puts '!always!'")
+    assert_success "bin/rails runner 'puts 2'", stdout: "!always!\n!callback!\n2"
+    assert_success "bin/spring status", stdout: "!always!"
+  end
+
   test "missing config/application.rb" do
     app.application_config.delete
     assert_failure "bin/rake -T", stderr: "unable to find your config/application.rb"

--- a/test/acceptance/helper.rb
+++ b/test/acceptance/helper.rb
@@ -125,6 +125,10 @@ module Spring
         path "config/spring.rb"
       end
 
+      def project_root_spring_config
+        path ".spring.rb"
+      end
+
       def run(command, opts = {})
         start_time = Time.now
 


### PR DESCRIPTION
Our own unique little snowflake of a Rails App has multiple facets (www.sauspiel.de vs www.skatstube.de vs www.fuchstreff.de) that are loaded depending on an environment variable `APP`. So when developing we run multiple instances of `rails server` with different `ENV['APP']`.

We recently updated to Rails 4.1.0.rc2 and wanted to use spring in our development workflow.

In order to make this work with spring I had to monkey patch `Spring::Env`, but there was no good point to hook into spring. That's why I added support for a `.spring.rb` in the project root that is loaded before calling the spring `Command`, so it's a good place to modify spring for our own unique needs.

In our concrete case it looks like this:

``` ruby
ENV['APP'] ||= begin
  config_file = File.expand_path('../.app', __FILE__)
  File.read(config_file).chomp if File.exists?(config_file)
end
abort "No or invalid APP, run something like this instead: APP=sauspiel #{$0} #{ARGV.tap(&:shift).join(" ")}" unless %w(bummerl fuchstreff sauspiel skatstube).include?(ENV['APP'])

abort "You're using an unsupported spring version. Check that it works and then update the check in .spring.rb" unless Spring::VERSION == "1.1.2"

module Spring
  class Env
    def app_name
      ENV['APP']
    end

    def application_id
      Digest::MD5.hexdigest(ENV['APP'])
    end
  end
end
```

An alternative, instead of introducing yet another config file that gets loaded at another point during startup, would be to always load `config/spring.rb` early and use `Spring.after_fork` or another (to be added) callback for stuff that has performance implications and should only run once.

But I saw in the changelog that the point where `config/spring.rb` gets loaded was already changed once "so you can require stuff from other gems there without performance implications". (16f5a24b776ac70e79835f9c5621d150ad5d0dc3 / #79)

I'd be happy to make such a change if it means we can use spring in our application.
