### PR TITLE
State Bundler dependency

### DIFF
--- a/spring.gemspec
+++ b/spring.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.add_dependency 'bundler', '>= 1.3.0', '< 2.0'
   gem.add_development_dependency 'activesupport'
   gem.add_development_dependency 'rake'
 end


### PR DESCRIPTION
This PR states Bundler dependency as spring is not independent on Bundler.

Resolves https://github.com/rails/spring/issues/275
