### PR TITLE
Doesn't reload after secrets.yml changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next release
+
+* Add `config/secrets.yml` file to watched for changes by default. Issue #289.
+
 ## 1.1.3
 
 * The `rails runner` command no longer passes environment switches to

--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -108,6 +108,9 @@ module Spring
       if defined?(Rails) && Rails.application
         watcher.add Rails.application.paths["config/initializers"]
         watcher.add Rails.application.paths["config/database"]
+        if secrets_path = Rails.application.paths["config/secrets"]
+          watcher.add secrets_path
+        end
       end
     end
 


### PR DESCRIPTION
I'm not sure if this should be in spring itself or should developer add it to custom watch command. `config/secrets.yml` is one of default files in rails 4.1 so maybe it should be included out of the box. What do you think?
