### PR TITLE
Respect -e and --environment options for rails console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next Version
+
+* Accept -e and --environment options for `rails console`.
+
 ## 1.1.3
 
 * The `rails runner` command no longer passes environment switches to

--- a/lib/spring/commands/rails.rb
+++ b/lib/spring/commands/rails.rb
@@ -13,7 +13,19 @@ module Spring
 
     class RailsConsole < Rails
       def env(args)
-        args.first if args.first && !args.first.index("-")
+        return args.first if args.first && !args.first.index("-")
+
+        environment = nil
+
+        args.each.with_index do |arg, i|
+          if arg =~ /--environment=(\w+)/
+            environment = $1
+          elsif i > 0 && args[i - 1] == "-e"
+            environment = arg
+          end
+        end
+
+        environment
       end
 
       def command_name

--- a/test/unit/commands_test.rb
+++ b/test/unit/commands_test.rb
@@ -7,7 +7,17 @@ class CommandsTest < ActiveSupport::TestCase
     assert_equal 'test', command.env(['test'])
   end
 
-  test 'console command ignores first argument if it is a flag' do
+  test 'console command sets rails environment from -e option' do
+    command = Spring::Commands::RailsConsole.new
+    assert_equal 'test', command.env(['-e', 'test'])
+  end
+
+  test 'console command sets rails environment from --environment option' do
+    command = Spring::Commands::RailsConsole.new
+    assert_equal 'test', command.env(['--environment=test'])
+  end
+
+  test 'console command ignores first argument if it is a flag except -e and --environment' do
     command = Spring::Commands::RailsConsole.new
     assert_nil command.env(['--sandbox'])
   end


### PR DESCRIPTION
I'm running Rails 4.0.5 and Spring 1.1.3. The -e and --environment options don't seem to work as expected.

There are four ways to set the environment for the rails console, and only the first two work:
1. RAILS_ENV=test rails console
2. rails console test
3. rails console -e test
4. rails console --environment=test

**Steps to reproduce:**

I added the following line to an initializer: 

``` ruby
puts "The environment is currently: #{Rails.env}"
```

```
$ spring stop
=> Spring stopped.

$ rails c -e test
=> The environment is currently: development
Loading test environment (Rails 4.0.5)
[1] pry(main)> Rails.env
=> "test"
```
