### PR TITLE
Make sure running `bin/spring` does not add an empty string to `Gem.path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Accept -e and --environment options for `rails console`.
 * Add `config/secrets.yml` file to watched for changes by default. Issue #289.
+* Make sure running `bin/spring` does not add an empty string to `Gem.path`.
+  Issues #297, #310.
 
 ## 1.1.3
 

--- a/lib/spring/client/binstub.rb
+++ b/lib/spring/client/binstub.rb
@@ -38,7 +38,7 @@ unless defined?(Spring)
 
   if match = Bundler.default_lockfile.read.match(/^GEM$.*?^    spring \((.*?)\)$.*?^$/m)
     ENV["GEM_PATH"] = ([Bundler.bundle_path.to_s] + Gem.path).join(File::PATH_SEPARATOR)
-    ENV["GEM_HOME"] = ""
+    ENV["GEM_HOME"] = nil
     Gem.paths = ENV
 
     gem "spring", match[1]


### PR DESCRIPTION
An empty string in `Gem.path` causes issues in third party gems like rvm or better_errors. See #297 and #310.

This happens because `Gem.paths=` picks up `$GEM_HOME` even if it’s set to an empty string. Fixed by unsetting `$GEM_HOME`.
