### PR TITLE
Make tmp path configurable via env variable

### DIFF
--- a/lib/spring/env.rb
+++ b/lib/spring/env.rb
@@ -32,7 +32,7 @@ module Spring
     end
 
     def tmp_path
-      path = Pathname.new(Dir.tmpdir + "/spring")
+      path = Pathname.new(ENV["SPRING_TMP_PATH"] || Dir.tmpdir + "/spring")
       FileUtils.mkdir_p(path) unless path.exist?
       path
     end


### PR DESCRIPTION
My solution to the #326 issue: when working in a multi-user environment, each user can set their SPRING_TMP_PATH env variable to their own tmp directory. This prevents a whole bunch of "permission denied" errors.

I tested this in a real-world setup and it seems to be working just fine.
