### PR TITLE
Allow arbitrary setup code to be inserted into binstub

### DIFF
--- a/lib/spring/client/binstub.rb
+++ b/lib/spring/client/binstub.rb
@@ -104,8 +104,14 @@ CODE
             fallback = "require 'bundler/setup'\n" \
                        "load Gem.bin_path('#{command.gem_name}', '#{command.exec_name}')\n"
           end
+          if prelude = command.binstub_prelude
+            formatted_prelude = prelude.chomp.gsub(/^(?!$)/, '  ')
+            loader = LOADER.sub(/^end$/, "else\n#{formatted_prelude}\nend")
+          else
+            loader = LOADER
+          end
 
-          File.write(command.binstub, "#!/usr/bin/env ruby\n#{LOADER}#{fallback}")
+          File.write(command.binstub, "#!/usr/bin/env ruby\n#{loader}#{fallback}")
           command.binstub.chmod 0755
         end
 

--- a/lib/spring/command_wrapper.rb
+++ b/lib/spring/command_wrapper.rb
@@ -69,6 +69,12 @@ module Spring
       "bin/#{name}"
     end
 
+    def binstub_prelude
+      if command.respond_to?(:binstub_prelude)
+        command.binstub_prelude
+      end
+    end
+
     def exec
       if binstub.exist?
         binstub.to_s

--- a/test/acceptance/app_test.rb
+++ b/test/acceptance/app_test.rb
@@ -188,6 +188,25 @@ class AppTest < ActiveSupport::TestCase
     assert_success "bin/rake -T", stdout: "rake db:migrate"
   end
 
+  test "binstub with prelude code" do
+    prelude = "Prelude code line 1\nPrelude code line 2\n"
+
+    File.write(app.spring_config, <<-CODE)
+      class PreludeCode
+        def binstub_prelude
+          "#{prelude}"
+        end
+      end
+
+      Spring.register_command "prelude", PreludeCode.new
+    CODE
+
+    assert_success "bin/spring binstub prelude"
+    prelude.each_line do |line|
+      assert app.path("bin/prelude").read.include?(line), "'#{line}' not found in bin/prelude"
+    end
+  end
+
   test "binstub when spring is uninstalled" do
     app.run! "gem uninstall --ignore-dependencies spring"
     File.write(app.gemfile, app.gemfile.read.gsub(/gem 'spring.*/, ""))


### PR DESCRIPTION
This commit is designed to be the first step to solving this [issue](https://github.com/jonleighton/spring-commands-rspec/issues/18).

The pull request would allow the [spring-commands-rspec](https://github.com/jonleighton/spring-commands-rspec) gem to be changed to:

``` ruby
# lib/spring/commands/rspec.rb

module Spring
  module Commands
    class RSpec
      def env(*)
        "test"
      end

      def exec_name
        "rspec"
      end

      def gem_name
        "rspec-core"
      end

      def binstub_code
        "RSpec.configuration.start_time = Time.now"
      end
    end

    Spring.register_command "rspec", RSpec.new
    Spring::Commands::Rake.environment_matchers[/^spec($|:)/] = "test"
  end
end
```

The generated rspec binstub would then be:

``` ruby
#!/usr/bin/env ruby
begin
  load File.expand_path("../spring", __FILE__)
rescue LoadError
end
RSpec.configuration.start_time = Time.now
require 'bundler/setup'
load Gem.bin_path('rspec-core', 'rspec')
```
