### PR TITLE
fix preloading of app with hidden pty with lots of output

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -282,6 +282,7 @@ module Spring
     def with_pty
       PTY.open do |master, slave|
         [STDOUT, STDERR, STDIN].each { |s| s.reopen slave }
+        Thread.new { master.read }
         yield
         reset_streams
       end

--- a/test/acceptance/app_test.rb
+++ b/test/acceptance/app_test.rb
@@ -132,6 +132,17 @@ class AppTest < ActiveSupport::TestCase
     assert_app_reloaded
   end
 
+  test "app gets reloaded even with a ton of boot output" do
+    File.write(app.path("config/initializers/verbose.rb"), "50.times { puts 'x' * 80 }\n")
+    begin
+      app.env["RAILS_ENV"] = "test"
+      assert_success "bin/rails runner 'puts Spring.watcher.class'", stdout: "Polling"
+      assert_app_reloaded
+    ensure
+      File.unlink(app.path("config/initializers/verbose.rb"))
+    end
+  end
+
   test "app recovers when a boot-level error is introduced" do
     config = app.application_config.read
 


### PR DESCRIPTION
if we never read from the PTY, and the app spews a lot of messages
on startup, it might hang because the buffer is full
