### PR TITLE
update binstub to find spring as a subdependency

### DIFF
--- a/lib/spring/client/binstub.rb
+++ b/lib/spring/client/binstub.rb
@@ -36,7 +36,7 @@ unless defined?(Spring)
   require "rubygems"
   require "bundler"
 
-  if match = Bundler.default_lockfile.read.match(/^GEM$.*?^    spring \((.*?)\)$.*?^$/m)
+  if match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m)
     ENV["GEM_PATH"] = ([Bundler.bundle_path.to_s] + Gem.path).join(File::PATH_SEPARATOR)
     ENV["GEM_HOME"] = ""
     Gem.paths = ENV


### PR DESCRIPTION
if you only add say spring-commands-rspec to your Gemfile, that will
automatically pull in the latest version of spring, but as a
sub-dependency, so there will be an extra line of indentation in the
lockfile
