### PR TITLE
fix gems that only add rake tasks

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -81,6 +81,10 @@ module Spring
 
       require Spring.application_root_path.join("config", "application")
 
+      Spring.commands.each_value do |command|
+        command.preload
+      end
+
       # config/environments/test.rb will have config.cache_classes = true. However
       # we want it to be false so that we can reload files. This is a hack to
       # override the effect of config.cache_classes = true. We can then actually

--- a/lib/spring/command_wrapper.rb
+++ b/lib/spring/command_wrapper.rb
@@ -18,6 +18,10 @@ module Spring
       end
     end
 
+    def preload
+      command.preload if command.respond_to?(:preload)
+    end
+
     def setup?
       @setup
     end

--- a/lib/spring/commands/rake.rb
+++ b/lib/spring/commands/rake.rb
@@ -23,6 +23,11 @@ module Spring
 
         nil
       end
+
+      def preload
+        puts 'requiring rake tasks'
+        Bundler.require(:rake_tasks)
+      end
     end
 
     Spring.register_command "rake", Rake.new


### PR DESCRIPTION
if a gem is in the rake_tasks group, it is supposed to required for
`rake`. Unfortunately, this wasn't working correctly because with
spring the app had already been initialized and had cached all
railties, so the Rakefile require rake_tasks loaded the gems,
but loading of the actual rake tasks couldn't find the railties.

This commit adds a hook for commands to preload things after
config/application has been required (and the main part of
the bundle required), but before the application actually
initializes. Rake command takes advantage of this require the
rake_tasks group
