### PR TITLE
Update direnv info with specific PATH_add example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ will just be silently ignored and the lines after it will be executed as
 normal.
 
 If you don't want to prefix every command you type with `bin/`, you
-can [use direnv](https://github.com/zimbatm/direnv) to automatically add
-`./bin` to your `PATH` when you `cd` into your application.
+can [use direnv](https://github.com/zimbatm/direnv#the-stdlib) to
+automatically add `./bin` to your `PATH` when you `cd` into your application.
+Simply create an `.envrc` file with the command `PATH_add bin` in your
+Rails directory.
 
 ### Usage
 


### PR DESCRIPTION
Adding `./bin` to `PATH` using direnv `.envrc` can be problematic in Bash; see https://github.com/zimbatm/direnv/issues/133. Update to use `PATH_add` instead, which expands the full directory name.
