### PR TITLE
prefer $XDG_RUNTIME_DIR for pid file and socket

### DIFF
--- a/lib/spring/env.rb
+++ b/lib/spring/env.rb
@@ -32,7 +32,7 @@ module Spring
     end
 
     def tmp_path
-      path = Pathname.new(Dir.tmpdir + "/spring")
+      path = Pathname.new(File.join(ENV['XDG_RUNTIME_DIR'] || Dir.tmpdir, "spring"))
       FileUtils.mkdir_p(path) unless path.exist?
       path
     end


### PR DESCRIPTION
According to the [XDG Base Directory Specification](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html), sockets and pid files should go into XDG_RUNTIME_DIR.
