### PR TITLE
Fix hang when the app writes lots of stdout/stderr

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -282,8 +282,15 @@ module Spring
     def with_pty
       PTY.open do |master, slave|
         [STDOUT, STDERR, STDIN].each { |s| s.reopen slave }
+        interrupt = IO.pipe
+        Thread.new{ loop{
+          readable,_=IO.select([master,interrupt.first])
+          log master.read_nonblock(4096) if readable.include?(master)
+          break if readable == [interrupt.first]
+        }}
         yield
         reset_streams
+        interrupt.last.write '.'
       end
     end
 

--- a/test/acceptance/app_test.rb
+++ b/test/acceptance/app_test.rb
@@ -281,6 +281,12 @@ CODE
     assert_success "bin/spring status", stdout: "Spring is running"
   end
 
+  test "stdout doesn't block when full" do
+    assert_success app.spring_test_command
+    File.write(app.application_config, "#{app.application_config.read}\nputs 'hello world'*200")
+    assert_success app.spring_test_command
+  end
+
   test "runner command sets Rails environment from command-line options" do
     assert_success "bin/rails runner -e test 'puts Rails.env'", stdout: "test"
     assert_success "bin/rails runner --environment=test 'puts Rails.env'", stdout: "test"


### PR DESCRIPTION
Hi there - spring enabled commands when occasionally hang for me when trying to run them, which turned out to be due to excessive stuff being written to stdout on application startup, which would eventually fill the buffer and block. On my system, it would block after 1024 bytes on stdout.

Possibly this is the same problem being experienced in  https://github.com/rails/spring/issues/265.

This commit adds a thread to read from the PTY during eager load, and echo the result to the spring log file.  WDYT?
