### PR TITLE
Ensure Kernel.raise remains private after patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Custom Spring commands that implement `#binstub_prelude` will have that
   snippet of code inserted into generated binstubs just after Spring is
   set up. #329 - @merhard
+* Change monkey-patched `Kernel.raise` from public to private (to match default Ruby behavior) #351 - @mattbrictson
 
 ## 1.1.3
 

--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -270,6 +270,7 @@ module Spring
             end
           end
         end
+        private :raise
       end
     end
 

--- a/test/acceptance/app_test.rb
+++ b/test/acceptance/app_test.rb
@@ -350,4 +350,9 @@ CODE
     assert_success %(bin/rails runner 'p ENV["OMG"]'), stdout: "2"
     assert_success %(bin/rails runner 'p ENV.key?("FOO")'), stdout: "false"
   end
+
+  test "Kernel.raise remains private" do
+    expr = "p Kernel.private_instance_methods.include?(:raise)"
+    assert_success %(bin/rails runner '#{expr}'), stdout: "true"
+  end
 end


### PR DESCRIPTION
Kernel.raise is originally private, but define_method(:raise) creates a method that is public. Use `private :raise` to make the redefined method private to be consistent with default Ruby behavior.

Fixes #350.
