### PR TITLE
Fix usage of uninitialized ::DL in Ruby 1.9.3

### DIFF
--- a/lib/spring/sid.rb
+++ b/lib/spring/sid.rb
@@ -25,7 +25,7 @@ module Spring
         if Process.respond_to?(:getsid)
           # Ruby 2
           Process.getsid
-        elsif defined?(Fiddle)
+        elsif defined?(Fiddle) and defined?(DL)
           # Ruby 1.9.3 compiled with libffi support
           fiddle_func.call(0)
         else


### PR DESCRIPTION
When compiling Ruby 1.9.3 with clang, Fiddle is compiled in while DL is not.
This commit fixes an usage of the DL module in the case it's not compiled in.

Unfortunately Fiddle::Handle and Fiddle.dlopen were only added in Ruby 2, but
a dlopen call (available as part of the DL module) is needed to use
Fiddle::Function.

Fixes #274
