### PR TITLE
Changed the value used for $0 in subcommands

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -158,7 +158,7 @@ module Spring
         trap("TERM", "DEFAULT")
 
         ARGV.replace(args)
-        $0 = command.process_title
+        $0 = command.exec_name
 
         # Delete all env vars which are unchanged from before spring started
         original_env.each { |k, v| ENV.delete k if ENV[k] == v }

--- a/lib/spring/command_wrapper.rb
+++ b/lib/spring/command_wrapper.rb
@@ -41,10 +41,6 @@ module Spring
       end
     end
 
-    def process_title
-      [name, *ARGV].join(" ")
-    end
-
     def gem_name
       if command.respond_to?(:gem_name)
         command.gem_name


### PR DESCRIPTION
$0 should be the first element of argv, which is generally the name of the program being run. Right now Spring is including the rest of argv as well. This is a problem for RSpec, which varies its behavior based on $0.

There's a lot more information on this issue [here](/jonleighton/spring-commands-rspec/issues/21).

@jonleighton suggested fixing spring instead of spring-commands-rspec, and he also wrote the original code that this patch modifies, so this seems like a shoo-in.

Fixes #359
