### PR TITLE
Read a .spring.rb from the current directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next version
 
+* Read a `.spring.rb` from the local directory in addition to a global `~/.spring.rb`
 * Automatically restart spring after new commands are added. This means
   that you can add spring-commands-rspec to your Gemfile and then
   immediately start using it, without having to run `spring stop`.

--- a/README.md
+++ b/README.md
@@ -287,12 +287,12 @@ constants in your initialization code.
 
 ## Configuration
 
-Spring will read `~/.spring.rb` and `config/spring.rb` for custom
-settings. Note that `~/.spring.rb` is loaded *before* bundler, but
-`config/spring.rb` is loaded *after* bundler. So if you have any
-`spring-commands-*` gems installed that you want to be available in all
-projects without having to be added to the project's Gemfile, require
-them in your `~/.spring.rb`.
+Spring will read `~/.spring.rb`, `./.spring.rb` and `config/spring.rb` for
+custom settings. Note that `~/.spring.rb` and `./.spring.rb` are loaded
+*before* bundler, but `config/spring.rb` is loaded *after* bundler. So if you
+have any `spring-commands-*` gems installed that you want to be available in
+all projects without having to be added to the project's Gemfile, require them
+in your `~/.spring.rb` or `./.spring.rb`.
 
 ### Application root
 
@@ -307,9 +307,9 @@ Spring.application_root = './test/dummy'
 
 ### Running code before forking
 
-There is no `Spring.before_fork` callback. To run something before the
-fork, you can place it in `~/.spring.rb` or `config/spring.rb` or in any of the files
-which get run when your application initializes, such as
+There is no `Spring.before_fork` callback. To run something before the fork,
+you can place it in `~/.spring.rb`, `./.spring.rb` or `config/spring.rb` or in
+any of the files which get run when your application initializes, such as
 `config/application.rb`, `config/environments/*.rb` or
 `config/initializers/*.rb`.
 

--- a/lib/spring/commands.rb
+++ b/lib/spring/commands.rb
@@ -25,8 +25,10 @@ module Spring
 
   # Load custom commands, if any.
   # needs to be at the end to allow modification of existing commands.
-  config = File.expand_path("~/.spring.rb")
-  require config if File.exist?(config)
+  ["~", "."].each do |location|
+    config = File.expand_path File.join(location, ".spring.rb")
+    require config if File.exist?(config)
+  end
 
   # If the config/spring.rb contains requires for commands from other gems,
   # then we need to be under bundler.

--- a/lib/spring/test/acceptance_test.rb
+++ b/lib/spring/test/acceptance_test.rb
@@ -252,6 +252,11 @@ CODE
         assert_success "bin/rails runner 'puts 2'", stdout: "!callback!\n2"
       end
 
+      test "local config file evaluated" do
+        File.write("#{app.root}/.spring.rb", "Spring.after_fork { puts '!callback!' }")
+        assert_success "bin/rails runner 'puts 2'", stdout: "!callback!\n2"
+      end
+
       test "missing config/application.rb" do
         app.application_config.delete
         assert_failure "bin/rake -T", stderr: "unable to find your config/application.rb"


### PR DESCRIPTION
Spring already supports reading from `~/.spring.rb` and `config/spring.rb`. This PR adds a local `.spring.rb` in the current directory to the list of config files.

Rationale: `~/.spring.rb` is too global and `config/spring.rb` leaks into a Rails engine's host app.