### PR TITLE
Suggests plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.1
+
+* Improved help message - suggests installing appropriate plugin when a
+  known but uninstalled command is attempted.
+
 ## 1.3.0
 
 * Automatically restart spring after new commands are added. This means

--- a/lib/spring/client/help.rb
+++ b/lib/spring/client/help.rb
@@ -5,6 +5,8 @@ module Spring
     class Help < Command
       attr_reader :spring_commands, :application_commands
 
+      KNOWN_PLUGINS = %(rspec cucumber spinach teaspoon testunit)
+
       def self.description
         "Print available commands."
       end
@@ -29,12 +31,18 @@ module Spring
         puts formatted_help
       end
 
+      def help_for_missing_plugin(name)
+        return [] unless KNOWN_PLUGINS.include?(name)
+        [ '',  "Hint: you probably want to add the 'spring-commands-#{name}' gem"]
+      end
+
       def formatted_help
         ["Version: #{env.version}\n",
          "Usage: spring COMMAND [ARGS]\n",
          *command_help("spring itself", spring_commands),
          '',
-         *command_help("your application", application_commands)].join("\n")
+         *command_help("your application", application_commands),
+         *help_for_missing_plugin(Array(args).first)].join("\n")
       end
 
       def command_help(subject, commands)

--- a/test/unit/client/help_test.rb
+++ b/test/unit/client/help_test.rb
@@ -57,4 +57,10 @@ Commands for your application:
 
     assert_equal expected_output.chomp, @help.formatted_help
   end
+
+  test "formatted_help knows about missing plugins" do
+    rspec_help = Spring::Client::Help.new('rspec', spring_commands, application_commands)
+    assert_match /spring-commands-rspec/, rspec_help.formatted_help
+  end
+
 end


### PR DESCRIPTION
"spring rspec" and other commands supported by "spring-commands-*" plugins are unknown by default, and the path forward is not obvious to a beginner.

This change simply adds a line to the help output when one of these commands is attempted:

Hint: you probably want to add the 'spring-commands-FOO' gem

for any FOO currently in the spring-commands-* list in the README.  For all other unknown commands, the output is unchanged.