### PR TITLE
Add rails test command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Not released
+
+* Add `rails test` command.
+
 ## 1.3.3
 
 * Fix yet another problem with loading spring which seems to affect

--- a/lib/spring/client/rails.rb
+++ b/lib/spring/client/rails.rb
@@ -3,13 +3,14 @@ require "set"
 module Spring
   module Client
     class Rails < Command
-      COMMANDS = Set.new %w(console runner generate destroy)
+      COMMANDS = Set.new %w(console runner generate destroy test)
 
       ALIASES = {
         "c" => "console",
         "r" => "runner",
         "g" => "generate",
-        "d" => "destroy"
+        "d" => "destroy",
+        "t" => "test"
       }
 
       def self.description

--- a/lib/spring/commands/rails.rb
+++ b/lib/spring/commands/rails.rb
@@ -83,9 +83,16 @@ module Spring
       end
     end
 
+    class RailsTest < Rails
+      def command_name
+        "test"
+      end
+    end
+
     Spring.register_command "rails_console",  RailsConsole.new
     Spring.register_command "rails_generate", RailsGenerate.new
     Spring.register_command "rails_destroy",  RailsDestroy.new
     Spring.register_command "rails_runner",   RailsRunner.new
+    Spring.register_command "rails_test",     RailsTest.new
   end
 end


### PR DESCRIPTION
review @rafaelfranca @dhh 

I tried testing this in a rails app I have using `gem 'spring', '~> 1.3.3', github: 'arthurnn/spring'` on my gemfile, but for some reason it was saying that the test command didnt exist.
I am not sure if it is my setup or something, what it looked like was that the spring server was not running the new code, so it didnt have the test command or something like that.