### PR TITLE
Lock the version of the spawned server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.3.5
 
 * Fix `rails test` command to run in test environment #403 - @eileencodes
+* Ensure the spawned server is loaded from the same version of the Spring gem
+  as the client. Issue #295.
 
 ## 1.3.4
 

--- a/lib/spring/client/run.rb
+++ b/lib/spring/client/run.rb
@@ -68,8 +68,7 @@ module Spring
         pid = Process.spawn(
           gem_env,
           "ruby",
-          "-r", "spring/server",
-          "-e", "Spring::Server.boot"
+          "-e", "gem 'spring', '#{Spring::VERSION}'; require 'spring/server'; Spring::Server.boot"
         )
 
         until env.socket_path.exist?


### PR DESCRIPTION
This fixes a bug when the currently-executing version of Spring is not the most recent version available in the gem path. Previously, this would launch the most recent server version and cause an error when Bundler detects the mismatch.

Fixes #295.