### PR TITLE
Ensure `bin/rails test command defaults to `test` env

### DIFF
--- a/lib/spring/commands/rails.rb
+++ b/lib/spring/commands/rails.rb
@@ -84,6 +84,20 @@ module Spring
     end
 
     class RailsTest < Rails
+      def env(args)
+        environment = "test"
+
+        args.each.with_index do |arg, i|
+          if arg =~ /--environment=(\w+)/
+            environment = $1
+          elsif i > 0 && args[i - 1] == "-e"
+            environment = arg
+          end
+        end
+
+        environment
+      end
+
       def command_name
         "test"
       end

--- a/test/unit/commands_test.rb
+++ b/test/unit/commands_test.rb
@@ -56,4 +56,19 @@ class CommandsTest < ActiveSupport::TestCase
     assert_equal "test", command.env(["test:models"])
     assert_nil command.env(["test_foo"])
   end
+
+  test 'RailsTest#command defaults to test rails environment' do
+    command = Spring::Commands::RailsTest.new
+    assert_equal 'test', command.env([])
+  end
+
+  test 'RailsTest#command sets rails environment from --environment option' do
+    command = Spring::Commands::RailsTest.new
+    assert_equal 'foo', command.env(['--environment=foo'])
+  end
+
+  test 'RailsTest#command sets rails environment from -e option' do
+    command = Spring::Commands::RailsTest.new
+    assert_equal 'foo', command.env(['-e', 'foo'])
+  end
 end


### PR DESCRIPTION
`bin/rails test` was defauling to the `development` environment because
`ENV['RAILS_ENV']` and `ENV['RACK_ENV']` are nil and `default_rails_env`
defaults to the `development` environment when an environment is not
provided.

This resulted in Spring ignoring even explicitly setting the environment
option when running tests. The environment would get overwritten with
`development` even when `test` was set. Tests seemed to run fine, but if
there was a required file or included module the test would not be able
to find those files because the environment was set incorrectly.

Borrowing code from `RailsConsole` I updated `RailsTest` to set the
default env to `test` but take `--environment` and `-e` into account
like the other commands.

I added tests to ensure that when not set the environment will default
to `test`.

---

Note: I opened a PR instead of pushing because I haven't work with Spring before. This seems like the right change based on the other commands. :smile_cat: 