### PR TITLE
speed up tests by not copying bundled directory every time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+cache: bundler
+sudo: false
 rvm:
   - 1.9.3
   - 2.0.0

--- a/lib/spring/test/acceptance_test.rb
+++ b/lib/spring/test/acceptance_test.rb
@@ -194,9 +194,13 @@ module Spring
       end
 
       test "binstub when spring is uninstalled" do
-        app.run! "gem uninstall --ignore-dependencies spring"
-        File.write(app.gemfile, app.gemfile.read.gsub(/gem 'spring.*/, ""))
-        assert_success "bin/rake -T", stdout: "rake db:migrate"
+        begin
+          app.run! "gem uninstall --ignore-dependencies spring"
+          File.write(app.gemfile, app.gemfile.read.gsub(/gem 'spring.*/, ""))
+          assert_success "bin/rake -T", stdout: "rake db:migrate"
+        ensure
+          generator.build_and_install_gems
+        end
       end
 
       test "binstub upgrade" do

--- a/lib/spring/test/application.rb
+++ b/lib/spring/test/application.rb
@@ -48,7 +48,7 @@ module Spring
       end
 
       def gem_home
-        path "vendor/gems/#{RUBY_VERSION}"
+        path "../gems/#{RUBY_VERSION}"
       end
 
       def user_home


### PR DESCRIPTION
I noticed that the tests run super slow ... because we copy all the gems on every run.

`generator.copy_to(app.root)` takes about 2-3s on my machine,
with this patch it's kept in test/app/gems which makes the copy just take 0.04s

before: 4m33s
after: 2m51s

@rafaelfranca @amatsuda @jonleighton 
