### PR TITLE
support pre-boot hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,9 @@ settings. Note that `~/.spring.rb` is loaded *before* bundler, but
 projects without having to be added to the project's Gemfile, require
 them in your `~/.spring.rb`.
 
+`config/spring_preboot.rb` is also loaded before bundler and before a 
+server process is started, it can be used to add new top-level commands.
+
 ### Application root
 
 Spring must know how to find your Rails application. If you have a

--- a/lib/spring/client.rb
+++ b/lib/spring/client.rb
@@ -36,3 +36,9 @@ module Spring
     end
   end
 end
+
+# allow users to add hooks that do not run in the server
+# or modify start/stop
+if File.exist?("config/spring_preboot.rb")
+  require "./config/spring_preboot.rb"
+end

--- a/lib/spring/test/acceptance_test.rb
+++ b/lib/spring/test/acceptance_test.rb
@@ -262,6 +262,13 @@ module Spring
         assert_success "bin/rails runner 'puts 2'", stdout: "!callback!\n2"
       end
 
+      test "can define preboot tasks" do
+        File.write("#{app.spring_config.sub('.rb', '_preboot.rb')}", <<-RUBY)
+          Spring::Client::COMMANDS["foo"] = lambda { |args| puts "bar -- \#{args.inspect}" }
+        RUBY
+        assert_success "bin/spring foo --baz", stdout: "bar -- [\"foo\", \"--baz\"]\n"
+      end
+
       test "missing config/application.rb" do
         app.application_config.delete
         assert_failure "bin/rake -T", stderr: "unable to find your config/application.rb"


### PR DESCRIPTION
@jonleighton @rafaelfranca 

a solution for https://github.com/grosser/parallel_tests/issues/412

also allows a few hacks I had in mind:
 - make stop pgrep and kill all matching processes (to fix random orphans I saw)
 - add `start` so you have to `spring start` in a separate tab and see the log output there

(obviously needs tests etc, but direction looks good ?)