### PR TITLE
add bump to get rake bump:patch/minor/major tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
+require "bundler/setup"
 require "bundler/gem_tasks"
 require "rake/testtask"
+require "bump/tasks"
 
 namespace :test do
   Rake::TestTask.new(:unit) do |t|

--- a/spring.gemspec
+++ b/spring.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'activesupport', '~> 4.2.0'
   gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'bump'
 end


### PR DESCRIPTION
makes it easy (no need to search where the version is stored) and error-free to bump the version (changes + bundles + commits for you)

@rafaelfranca @jonleighton 