### PR TITLE
make help more accessible

### DIFF
--- a/lib/spring/client.rb
+++ b/lib/spring/client.rb
@@ -14,12 +14,14 @@ module Spring
   module Client
     COMMANDS = {
       "help"      => Client::Help,
+      "-h"        => Client::Help,
+      "--help"    => Client::Help,
       "binstub"   => Client::Binstub,
       "stop"      => Client::Stop,
       "status"    => Client::Status,
       "rails"     => Client::Rails,
       "-v"        => Client::Version,
-      "--version" => Client::Version
+      "--version" => Client::Version,
     }
 
     def self.run(args)

--- a/lib/spring/test/acceptance_test.rb
+++ b/lib/spring/test/acceptance_test.rb
@@ -84,6 +84,14 @@ module Spring
 
       test "help message when called without arguments" do
         assert_success "bin/spring", stdout: 'Usage: spring COMMAND [ARGS]'
+        assert app.spring_env.server_running?
+      end
+
+      test "shows help" do
+        assert_success "bin/spring help", stdout: 'Usage: spring COMMAND [ARGS]'
+        assert_success "bin/spring -h", stdout: 'Usage: spring COMMAND [ARGS]'
+        assert_success "bin/spring --help", stdout: 'Usage: spring COMMAND [ARGS]'
+        refute app.spring_env.server_running?
       end
 
       test "test changes are picked up" do


### PR DESCRIPTION
@jonleighton @rafaelfranca 

I found myself using `spring -h` twice already ... would be nice if it was consistent with other commands and did not try to start a server (and keep it running in the background) when I use `-h` / `--help` because I might be a new user and not even know that springs wants `spring help`
