### PR TITLE
Watch files autoloaded by AS::Dependencies during initialization.

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -103,8 +103,7 @@ module Spring
       watcher.add e.backtrace.map { |line| line.match(/^(.*)\:\d+\:in /)[1] }
       raise e unless initialized?
     ensure
-      watcher.add loaded_application_features
-      watcher.add loaded_application_dependencies
+      watcher.add loaded_application_files
       watcher.add Spring.gemfile, "#{Spring.gemfile}.lock"
 
       if defined?(Rails) && Rails.application
@@ -235,8 +234,7 @@ module Spring
     def setup(command)
       if command.setup
         # Loaded features may have changed.
-        watcher.add loaded_application_features
-        watcher.add loaded_application_dependencies
+        watcher.add loaded_application_files
       end
     end
 
@@ -244,6 +242,10 @@ module Spring
       Spring.after_fork_callbacks.each do |callback|
         callback.call
       end
+    end
+
+    def loaded_application_files
+      loaded_application_features + loaded_application_dependencies
     end
 
     def loaded_application_features

--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -256,10 +256,11 @@ module Spring
       loaded = ActiveSupport::Dependencies.loaded
 
       # The loaded_paths do not include file suffixes. Find all matches.
-      dlexts = RbConfig::CONFIG.values_at('DLEXT', 'DLEXT2')
-      ext_glob = "{rb,#{dlexts.reject { |s| s.to_s.empty? }.join(',')}}"
+      extensions = ['rb'] + RbConfig::CONFIG.values_at('DLEXT', 'DLEXT2').
+        reject { |s| s.to_s.empty? }
+      extension_glob = "{#{extensions.join(',')}}"
       loaded.select { |path| path.start_with?(root) }.flat_map do |path|
-        Dir["#{path}.#{ext_glob}"]
+        Dir["#{path}.#{extension_glob}"]
       end
     end
 

--- a/lib/spring/test/acceptance_test.rb
+++ b/lib/spring/test/acceptance_test.rb
@@ -2,6 +2,7 @@ require "io/wait"
 require "timeout"
 require "spring/sid"
 require "spring/client"
+require "spring/watcher"
 require "active_support/core_ext/string/strip"
 
 module Spring
@@ -107,10 +108,10 @@ module Spring
       test "code changes in pre-referenced app files trigger a restart" do
         File.write(app.path("app/models/test_constant.rb"), "TestConstant = 1\n")
         File.write(app.path("config/initializers/set_variable.rb"), "TEST_VALUE = TestConstant\n")
-
         assert_success app.spring_run_command('print TEST_VALUE'), stdout: "1"
 
         File.write(app.path("app/models/test_constant.rb"), "TestConstant = 2\n")
+        sleep Spring.watch_interval + 0.1
         assert_success app.spring_run_command('print TEST_VALUE'), stdout: "2"
       end
 

--- a/lib/spring/test/application.rb
+++ b/lib/spring/test/application.rb
@@ -67,6 +67,10 @@ module Spring
         "#{rails_version.test_command} #{test}"
       end
 
+      def spring_run_command(code)
+        "bin/rails runner \"#{code}\""
+      end
+
       def stop_spring
         run "#{spring} stop"
       rescue Errno::ENOENT


### PR DESCRIPTION
Without this, modules that are loaded during initialization, and stored in a global reference (including modules mixed in to core or library classes) would not trigger a spring restart when modified.

A simple demo of the problem is below. Although `TestConstant` is reloaded correctly when modified, `TEST_VALUE` remains stale. Another (perhaps more common) example of this pattern is mixing a module into a core class or a class from a gem during initialization. In that case, it can lead to the puzzling "A copy of X has been removed from the module tree but is still active!" error.
## Demo

Apply to a new Rails app:

``` diff
diff --git a/config/application.rb b/config/application.rb
index 11b2ec6..a57aa19 100644
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,7 @@ module Springy

     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.autoload_paths << "#{Rails.root}/lib"
   end
 end
diff --git a/config/initializers/test.rb b/config/initializers/test.rb
new file mode 100644
index 0000000..b34f716
--- /dev/null
+++ b/config/initializers/test.rb
@@ -0,0 +1,2 @@
+TEST_VALUE = TestConstant
+
diff --git a/lib/test_constant.rb b/lib/test_constant.rb
new file mode 100644
index 0000000..eb99609
--- /dev/null
+++ b/lib/test_constant.rb
@@ -0,0 +1 @@
+TestConstant = 2
```
