### PR TITLE
Prefer single-quoted strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ code into relevant existing executables. The snippet looks like this:
 
 ``` ruby
 begin
-  load File.expand_path("../spring", __FILE__)
+  load File.expand_path('../spring', __FILE__)
 rescue LoadError
 end
 ```
@@ -295,7 +295,7 @@ settings. Note that `~/.spring.rb` is loaded *before* bundler, but
 projects without having to be added to the project's Gemfile, require
 them in your `~/.spring.rb`.
 
-`config/spring_client.rb` is also loaded before bundler and before a 
+`config/spring_client.rb` is also loaded before bundler and before a
 server process is started, it can be used to add new top-level commands.
 
 ### Application root

--- a/lib/spring/client/binstub.rb
+++ b/lib/spring/client/binstub.rb
@@ -13,7 +13,7 @@ module Spring
       # should cause the "unsprung" version of the command to run.
       LOADER = <<CODE
 begin
-  load File.expand_path("../spring", __FILE__)
+  load File.expand_path('../spring', __FILE__)
 rescue LoadError
 end
 CODE
@@ -33,13 +33,13 @@ CODE
 # It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)
-  require "rubygems"
-  require "bundler"
+  require 'rubygems'
+  require 'bundler'
 
   if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
-    Gem.paths = { "GEM_PATH" => [Bundler.bundle_path.to_s, *Gem.path].uniq }
-    gem "spring", match[1]
-    require "spring/binstub"
+    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq }
+    gem 'spring', match[1]
+    require 'spring/binstub'
   end
 end
 CODE


### PR DESCRIPTION
RuboCop's [Style/StringLiterals](http://www.rubydoc.info/github/bbatsov/rubocop/Rubocop/Cop/Style/StringLiterals) recommends to:

> Prefer single-quoted strings when you don't need string interpolation or special symbols

I understand that the camps are divided around nitpicks like this one, but this minimal and inexpensive change—in both the docs and the generated code—can reduce number of notices a new user would get.