### PR TITLE
Add WINCH to FORWARDED_SIGNALS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add support for client side hooks. `config/spring_client.rb` is loaded before
   bundler and before a server process is started, it can be used to add new
   top-level commands.
+* Enable terminal resize detection in rails console.
 
 ## 1.3.6
 

--- a/lib/spring/client/run.rb
+++ b/lib/spring/client/run.rb
@@ -5,7 +5,7 @@ require "bundler"
 module Spring
   module Client
     class Run < Command
-      FORWARDED_SIGNALS = %w(INT QUIT USR1 USR2 INFO) & Signal.list.keys
+      FORWARDED_SIGNALS = %w(INT QUIT USR1 USR2 INFO WINCH) & Signal.list.keys
       TIMEOUT = 1
 
       def initialize(args)


### PR DESCRIPTION
This is necessary, in conjunction with a change in ~/.irbrc, to enable terminal window resizing while using spring.

    Signal.trap('SIGWINCH', proc { Readline.set_screen_size(*`stty size`.split.map(&:to_i)); Readline.refresh_line })