### PR TITLE
Make the temporary directory path contain uid of the process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next Release
+
+* Make the temporary directory path used by spring contain the UID of the process
+  so that spring can work on machines where multiple users share a single $TMPDIR.
+
 ## 1.4.3
 
 * Support new binstub format and --remove option

--- a/lib/spring/env.rb
+++ b/lib/spring/env.rb
@@ -33,7 +33,7 @@ module Spring
     end
 
     def tmp_path
-      path = Pathname.new(File.join(ENV['XDG_RUNTIME_DIR'] || Dir.tmpdir, "spring"))
+      path = Pathname.new(File.join(ENV['XDG_RUNTIME_DIR'] || Dir.tmpdir, "spring-#{Process.uid}"))
       FileUtils.mkdir_p(path) unless path.exist?
       path
     end


### PR DESCRIPTION
This patch resolves #376 a problem with multi-user environment.

On many traditional *nix systems all the users on the same machine share a single global `/tmp`.
If two users on such a system run spring at the same time, the first user's spring process
creates `/tmp/spring` and stores a pidfile and a socket within the directory.
The second users process will then try to store its pidfile within `/tmp/spring`, but it fails
since the directory is owned by another user and (usually) not writable to non-owners.

This patch resolves this problem by making the temporary directory path used by spring
contain the UID of the running process.
If you are the user with UID of 1000, your spring processes will create the directory
`$TMPDIR/spring-1000` and store everything therein.

----

Two other solutions are suggested on the issue #376 

1. Use `tmp` directory inside the Rails application's tree
1. Make `/tmp/spring` world-writable

I think both of them have some problem
- As pointed out in the issue, Rails `tmp` may reside within a filesystem without domain socket support.
- Making `/tmp/spring` is not safe --- Let other users delete your socket.

AFAIK, Emacs and tmux takes this solution with process's UID to store per-user server socket in the global `/tmp` directory.