### PR TITLE
Don't supress non-spring load errors in binstub

### DIFF
--- a/lib/spring/client/binstub.rb
+++ b/lib/spring/client/binstub.rb
@@ -13,8 +13,10 @@ module Spring
       # should cause the "unsprung" version of the command to run.
       LOADER = <<CODE
 begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError
+  spring_bin_path = File.expand_path('../spring', __FILE__)
+  load spring_bin_path
+rescue LoadError => e
+  raise unless e.message.end_with? spring_bin_path, 'spring/binstub'
 end
 CODE
 

--- a/lib/spring/test/acceptance_test.rb
+++ b/lib/spring/test/acceptance_test.rb
@@ -208,10 +208,19 @@ module Spring
         assert_success "bin/rake -T", stdout: "rake db:migrate"
       end
 
-      test "binstub when spring is uninstalled" do
+      test "binstub when spring gem is missing" do
         without_gem "spring-#{Spring::VERSION}" do
           File.write(app.gemfile, app.gemfile.read.gsub(/gem 'spring.*/, ""))
           assert_success "bin/rake -T", stdout: "rake db:migrate"
+        end
+      end
+
+      test "binstub when spring binary is missing" do
+        begin
+          File.rename(app.path("bin/spring"), app.path("bin/spring.bak"))
+          assert_success "bin/rake -T", stdout: "rake db:migrate"
+        ensure
+          File.rename(app.path("bin/spring.bak"), app.path("bin/spring"))
         end
       end
 


### PR DESCRIPTION
Without this change, the spring binstub supresses unrelated load errors, eg. due to errors in initializers or loaded gems. This change causes the binstub to only ignore a missing spring loader or gem.

This will get rid of the misleading `warning: already initialized constant APP_PATH` and resolves #259.