### PR TITLE
Fix upgrade/remove with new binstub variations

### DIFF
--- a/lib/spring/client/binstub.rb
+++ b/lib/spring/client/binstub.rb
@@ -119,7 +119,7 @@ CODE
       attr_reader :bindir, :items
 
       def self.description
-        "Generate spring based binstubs. Use --all to generate a binstub for all known commands."
+        "Generate spring based binstubs. Use --all to generate a binstub for all known commands. Use --remove to revert."
       end
 
       def self.rails_command

--- a/lib/spring/client/binstub.rb
+++ b/lib/spring/client/binstub.rb
@@ -48,6 +48,12 @@ CODE
 
       OLD_BINSTUB = %{if !Process.respond_to?(:fork) || Gem::Specification.find_all_by_name("spring").empty?}
 
+      BINSTUB_VARIATIONS = Regexp.union [
+        %{begin\n  load File.expand_path("../spring", __FILE__)\nrescue LoadError\nend\n},
+        %{begin\n  load File.expand_path('../spring', __FILE__)\nrescue LoadError\nend\n},
+        LOADER
+      ]
+
       class Item
         attr_reader :command, :existing
 
@@ -74,8 +80,12 @@ CODE
               fallback = nil if fallback.include?("exec")
               generate(fallback)
               status "upgraded"
-            elsif existing =~ /load .*spring/
+            elsif existing.include?(LOADER)
               status "spring already present"
+            elsif existing =~ BINSTUB_VARIATIONS
+              upgraded = existing.sub(BINSTUB_VARIATIONS, LOADER)
+              File.write(command.binstub, upgraded)
+              status "upgraded"
             else
               head, shebang, tail = existing.partition(SHEBANG)
 
@@ -110,7 +120,7 @@ CODE
 
         def remove
           if existing
-            File.write(command.binstub, existing.sub(LOADER, ""))
+            File.write(command.binstub, existing.sub(BINSTUB_VARIATIONS, ""))
             status "spring removed"
           end
         end

--- a/lib/spring/test/acceptance_test.rb
+++ b/lib/spring/test/acceptance_test.rb
@@ -229,7 +229,7 @@ module Spring
         end
       end
 
-      test "binstub upgrade" do
+      test "binstub upgrade with old binstub" do
         File.write(app.path("bin/rake"), <<-RUBY.strip_heredoc)
           #!/usr/bin/env ruby
 
@@ -267,6 +267,93 @@ module Spring
         expected = <<-RUBY.gsub(/^          /, "")
           #!/usr/bin/env ruby
           #{Spring::Client::Binstub::LOADER.strip}
+          APP_PATH = File.expand_path('../../config/application',  __FILE__)
+          require_relative '../config/boot'
+          require 'rails/commands'
+        RUBY
+        assert_equal expected, app.path("bin/rails").read
+      end
+
+      test "binstub upgrade with new binstub variations" do
+        # older variation with double quotes
+        File.write(app.path("bin/rake"), <<-RUBY.strip_heredoc)
+          #!/usr/bin/env ruby
+          begin
+            load File.expand_path("../spring", __FILE__)
+          rescue LoadError
+          end
+          require 'bundler/setup'
+          load Gem.bin_path('rake', 'rake')
+        RUBY
+
+        # newer variation with single quotes
+        File.write(app.path("bin/rails"), <<-RUBY.strip_heredoc)
+          #!/usr/bin/env ruby
+          begin
+            load File.expand_path('../spring', __FILE__)
+          rescue LoadError
+          end
+          APP_PATH = File.expand_path('../../config/application',  __FILE__)
+          require_relative '../config/boot'
+          require 'rails/commands'
+        RUBY
+
+        assert_success "bin/spring binstub --all", stdout: "upgraded"
+
+        expected = <<-RUBY.gsub(/^          /, "")
+          #!/usr/bin/env ruby
+          #{Spring::Client::Binstub::LOADER.strip}
+          require 'bundler/setup'
+          load Gem.bin_path('rake', 'rake')
+        RUBY
+        assert_equal expected, app.path("bin/rake").read
+
+        expected = <<-RUBY.gsub(/^          /, "")
+          #!/usr/bin/env ruby
+          #{Spring::Client::Binstub::LOADER.strip}
+          APP_PATH = File.expand_path('../../config/application',  __FILE__)
+          require_relative '../config/boot'
+          require 'rails/commands'
+        RUBY
+        assert_equal expected, app.path("bin/rails").read
+      end
+
+      test "binstub remove with new binstub variations" do
+        # older variation with double quotes
+        File.write(app.path("bin/rake"), <<-RUBY.strip_heredoc)
+          #!/usr/bin/env ruby
+          begin
+            load File.expand_path("../spring", __FILE__)
+          rescue LoadError
+          end
+          require 'bundler/setup'
+          load Gem.bin_path('rake', 'rake')
+        RUBY
+
+        # newer variation with single quotes
+        File.write(app.path("bin/rails"), <<-RUBY.strip_heredoc)
+          #!/usr/bin/env ruby
+          begin
+            load File.expand_path('../spring', __FILE__)
+          rescue LoadError
+          end
+          APP_PATH = File.expand_path('../../config/application',  __FILE__)
+          require_relative '../config/boot'
+          require 'rails/commands'
+        RUBY
+
+        assert_success "bin/spring binstub --remove rake", stdout: "bin/rake: spring removed"
+        assert_success "bin/spring binstub --remove rails", stdout: "bin/rails: spring removed"
+
+        expected = <<-RUBY.strip_heredoc
+          #!/usr/bin/env ruby
+          require 'bundler/setup'
+          load Gem.bin_path('rake', 'rake')
+        RUBY
+        assert_equal expected, app.path("bin/rake").read
+
+        expected = <<-RUBY.strip_heredoc
+          #!/usr/bin/env ruby
           APP_PATH = File.expand_path('../../config/application',  __FILE__)
           require_relative '../config/boot'
           require 'rails/commands'

--- a/lib/spring/test/acceptance_test.rb
+++ b/lib/spring/test/acceptance_test.rb
@@ -208,6 +208,11 @@ module Spring
         assert_success "bin/rake -T", stdout: "rake db:migrate"
       end
 
+      test "binstub remove all" do
+        assert_success "bin/spring binstub --remove --all"
+        refute File.exist?(app.path("bin/spring"))
+      end
+
       test "binstub when spring gem is missing" do
         without_gem "spring-#{Spring::VERSION}" do
           File.write(app.gemfile, app.gemfile.read.gsub(/gem 'spring.*/, ""))


### PR DESCRIPTION
This is a followup to #444 which adds support for upgrading to the new loader code as well as supporting `bin/spring binstub --remove` with both single and double quoted variants of the previous loader code, which was not handled in #437.

I've also added an acceptance test for `bin/spring binstub --remove --all` which tests for the removal of `bin/spring` and added a mention of the `--remove` option to the spring client binstub help output.
