### PR TITLE
Mention spring-commands-rubocop gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ You can add these to your Gemfile for additional commands:
   to use `rake test path/to/test` to run a particular test/directory.
 * [spring-commands-teaspoon](https://github.com/alejandrobabio/spring-commands-teaspoon.git)
 * [spring-commands-m](https://github.com/gabrieljoelc/spring-commands-m.git)
+* [spring-commands-rubocop](https://github.com/p0deje/spring-commands-rubocop)
 
 ## Use without adding to bundle
 


### PR DESCRIPTION
Mentions https://github.com/p0deje/spring-commands-rubocop as a gem which adds `rubocop` command.