### PR TITLE
Add bundler Dependency to gemspec

### DIFF
--- a/lib/spring/test/application.rb
+++ b/lib/spring/test/application.rb
@@ -94,7 +94,7 @@ module Spring
         Bundler.with_clean_env do
           Process.spawn(
             env,
-            command.to_s,
+            "bundle exec #{command}",
             out:   stdout.last,
             err:   stderr.last,
             in:    :close,
@@ -200,7 +200,7 @@ module Spring
       end
 
       def bundle
-        run! "(gem list bundler | grep bundler) || gem install bundler", timeout: nil, retry: 2
+        run! "gem list bundler | grep bundler || gem install bundler", timeout: nil, retry: 2
         run! "bundle check || bundle update --retry=2", timeout: nil
       end
 

--- a/lib/spring/test/application_generator.rb
+++ b/lib/spring/test/application_generator.rb
@@ -85,9 +85,9 @@ module Spring
       def install_spring
         return if @installed
 
-        build_and_install_gems
-
         application.bundle
+
+        build_and_install_gems
 
         FileUtils.rm_rf application.path("bin")
 

--- a/spring.gemspec
+++ b/spring.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |gem|
   gem.files         = Dir["LICENSE.txt", "README.md", "lib/**/*", "bin/*"]
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
 
+  gem.add_dependency 'bundler', '>= 1.0'
   gem.add_development_dependency 'activesupport', '~> 4.2.0'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'bump'


### PR DESCRIPTION
`bundle exec` was added to acceptance test cause otherwise it was giving Gem::LoadError for conflicting bundler versions.

An alternate solution would have been to add it [here](https://github.com/rails/spring/blob/master/lib/spring/test/application.rb#L94-L103):

```Ruby
 Bundler.with_clean_env do
   Process.spawn(
     env,
     command.to_s,   # may be change this line to "bundle exec #{command}"
     out:   stdout.last,
     err:   stderr.last,
     in:    :close,
     chdir: root.to_s,
   )
 end
```
I felt it was non-intuitive. Additionally, above code block doesn't get called only from `Spring::Test::AcceptanceTest`, so it would need changes on many different files.

**EDIT:**
Resolves: #275 