### PR TITLE
Add bundler Dependency to gemspec, closes #275

### DIFF
--- a/lib/spring/test/application.rb
+++ b/lib/spring/test/application.rb
@@ -32,6 +32,7 @@ module Spring
         @env ||= {
           "GEM_HOME"   => gem_home.to_s,
           "GEM_PATH"   => gem_home.to_s,
+          "RUBYLIB"    => gem_home.to_s,
           "HOME"       => user_home.to_s,
           "RAILS_ENV"  => nil,
           "RACK_ENV"   => nil,

--- a/spring.gemspec
+++ b/spring.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |gem|
   gem.files         = Dir["LICENSE.txt", "README.md", "lib/**/*", "bin/*"]
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
 
+  gem.add_dependency 'bundler', '>= 1.0'
   gem.add_development_dependency 'activesupport', '~> 4.2.0'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'bump'


### PR DESCRIPTION
`RUBYLIB`, is used by Ruby as a search path for libraries, to include the Bundler library directory and it ended up using the older bundler.
`"RUBYLIB"` was using `home/user/.rvm/gems/ruby-2.2.1/gems/bundler-1.7.6/lib`
