### PR TITLE
update backtrace string format regex

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -99,7 +99,7 @@ module Spring
       @preloaded = :success
     rescue Exception => e
       @preloaded = :failure
-      watcher.add e.backtrace.map { |line| line.match(/^(.*)\:\d+\:in /)[1] }
+      watcher.add e.backtrace.map { |line| line[/^(.*)\:\d+/, 1] }
       raise e unless initialized?
     ensure
       watcher.add loaded_application_features


### PR DESCRIPTION
Every backtrace strings do not include `:in`
http://ruby-doc.org/core-1.9.3/Exception.html#method-i-backtrace