### PR TITLE
require "spring/commands" after boot_server

### DIFF
--- a/lib/spring/client/run.rb
+++ b/lib/spring/client/run.rb
@@ -1,4 +1,3 @@
-require "spring/commands"
 require "rbconfig"
 require "socket"
 require "bundler"
@@ -120,6 +119,8 @@ ERROR
       end
 
       def run_command(client, application)
+        require "spring/commands"
+
         log "sending command"
 
         application.send_io STDOUT


### PR DESCRIPTION
### What is PR
`require "spring/commands"` calls after `boot_server`, but calls before `run_command`.

Related to https://github.com/rails/spring/pull/458, https://github.com/rails/spring/pull/453, https://github.com/rails/spring/issues/456

### Environments

I experimented this environments.

* `ruby-2.2.3`
* `spring`
   * `spring-1.6.0`
   * `spring-1.6.1`
* `bundler`
   * `bundler-1.11.0`
   * `bundler-1.11.2`

### Problem

Use `spring-1.6.x` and `bundler-1.11.x` combination, spring command failed with follow error.

```zsh
% spring stop; rails c
Spring stopped.

/Users/hiromu/.rbenv/versions/2.2.3/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- bundler/setup (LoadError)
        from /Users/hiromu/.rbenv/versions/2.2.3/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /Users/hiromu/work/my-project/vendor/bundle/gems/spring-1.6.0/lib/spring/commands.rb:33:in `<module:Spring>'
        from /Users/hiromu/work/my-project/vendor/bundle/gems/spring-1.6.0/lib/spring/commands.rb:4:in `<top (required)>'
        from /Users/hiromu/.rbenv/versions/2.2.3/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /Users/hiromu/.rbenv/versions/2.2.3/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /Users/hiromu/work/my-project/vendor/bundle/gems/spring-1.6.0/lib/spring/application.rb:77:in `preload'
        from /Users/hiromu/work/my-project/vendor/bundle/gems/spring-1.6.0/lib/spring/application.rb:143:in `serve'
        from /Users/hiromu/work/my-project/vendor/bundle/gems/spring-1.6.0/lib/spring/application.rb:131:in `block in run'
        from /Users/hiromu/work/my-project/vendor/bundle/gems/spring-1.6.0/lib/spring/application.rb:125:in `loop'
        from /Users/hiromu/work/my-project/vendor/bundle/gems/spring-1.6.0/lib/spring/application.rb:125:in `run'
        from /Users/hiromu/work/my-project/vendor/bundle/gems/spring-1.6.0/lib/spring/application/boot.rb:18:in `<top (required)>'
        from /Users/hiromu/.rbenv/versions/2.2.3/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /Users/hiromu/.rbenv/versions/2.2.3/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from -e:1:in `<main>'
```


I think, there is same issue https://github.com/rails/spring/pull/458, https://github.com/rails/spring/pull/453, https://github.com/rails/spring/issues/456

### Reason

There is related two reason, this problem is complicative.
The one is that `Bundler.with_clean_env` problem refs [with_clean_env does not replace original RUBYLIB environmental variable · Issue #3982 · bundler/bundler](https://github.com/bundler/bundler/issues/3982).
The two is that `Spring::Client::Run#boot_server` receive `GEM_PATH` env, but if `require "bundler/setup"` overrides `Gem.path`, `Spring::Client::Run#boot_server` receives overrided env. Therefore child process does not found `bundler/setup`.

Summary is follow this.

* `bundler-1.10.x`
  * `spring-1.5.0`
      * `RUBYLIB` does not replace in `Bundler.with_clean_env`, therefore successes `require "bundler/setup"`
   * `spring-1.6.x`
      * `RUBYLIB` does not replace in `Bundler.with_clean_env`, therefore successes `require "bundler/setup"`
* `bundler-1.11.x`
   * `spring-1.5.0`
      * `RUBYLIB` replaced in `Bundler.with_clean_env`, BUT `Gem.path` does not override `Gem.path` because does not exist `require "spring/commands"`, therefore successes `require "bundler/setup"`
   * `spring-1.6.x`
      * `RUBYLIB` replaced in `Bundler.with_clean_env`, AND `Gem.path` overrides `Gem.path` because exist `require "spring/commands"`, therefore failed to `require "bundler/setup"`

# Feedback

What do you think this conclusion? Please let me any feedbacks.