### PR TITLE
Start server process in clean env, closes #456

### DIFF
--- a/lib/spring/client/run.rb
+++ b/lib/spring/client/run.rb
@@ -65,11 +65,14 @@ module Spring
       def boot_server
         env.socket_path.unlink if env.socket_path.exist?
 
-        pid = Process.spawn(
-          gem_env,
-          "ruby",
-          "-e", "gem 'spring', '#{Spring::VERSION}'; require 'spring/server'; Spring::Server.boot"
-        )
+        pid = nil
+        Bundler.with_clean_env do
+          pid = Process.spawn(
+            gem_env,
+            "ruby",
+            "-e", "gem 'spring', '#{Spring::VERSION}'; require 'spring/server'; Spring::Server.boot"
+          )
+        end
 
         until env.socket_path.exist?
           _, status = Process.waitpid2(pid, Process::WNOHANG)


### PR DESCRIPTION
ENV["GEM_PATH"] was empty string, so GEM_PATH and GEM_HOME passed to
server process were same path.
It used to work before bundler 1.11.0 release cause bundler didn't clean
ENV["RUBYLIB"] and `require bundler/setup` was using that instead.
Change in bundler: https://github.com/bundler/bundler/pull/4002