### PR TITLE
Set GEM_PATH as string as it does not accept arrays in RubyGems 2.6.0+

### DIFF
--- a/lib/spring/client/binstub.rb
+++ b/lib/spring/client/binstub.rb
@@ -38,7 +38,7 @@ unless defined?(Spring)
   require 'bundler'
 
   if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
-    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq }
+    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq.join(Gem.path_separator) }
     gem 'spring', match[1]
     require 'spring/binstub'
   end


### PR DESCRIPTION
Support for gem path arrays was removed in https://github.com/rubygems/rubygems/commit/27a436e91f1d83dc4a23168851d4d29a73fde752

It fixes https://github.com/rubygems/rubygems/issues/1511

