### PR TITLE
Use Gem.use_paths method for setting paths

### DIFF
--- a/lib/spring/client/binstub.rb
+++ b/lib/spring/client/binstub.rb
@@ -38,7 +38,7 @@ unless defined?(Spring)
   require 'bundler'
 
   if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
-    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq.join(Gem.path_separator) }
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
     gem 'spring', match[1]
     require 'spring/binstub'
   end


### PR DESCRIPTION
It fixes case for JRuby which returns a regexp from Gem.path_separator,
but also improves code by using built in method instead of passing string that later is changed to array again.

It follows discussion from https://github.com/rails/spring/pull/472/files#r54284442