### PR TITLE
Use the Rails 5 reloader API if available

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -149,8 +149,13 @@ module Spring
       setup command
 
       if Rails.application.reloaders.any?(&:updated?)
-        ActionDispatch::Reloader.cleanup!
-        ActionDispatch::Reloader.prepare!
+        # Rails 5.1 forward-compat. AD::R is deprecated to AS::R in Rails 5.
+        if defined? ActiveSupport::Reloader
+          Rails.application.reloader.reload!
+        else
+          ActionDispatch::Reloader.cleanup!
+          ActionDispatch::Reloader.prepare!
+        end
       end
 
       pid = fork {


### PR DESCRIPTION
Maintains compat with older Rails as well, but uses the new reloader API if it's available, avoiding a deprecation warning on Rails 5.0 and breakage on Rails 5.1.