### PR TITLE
Configure threads to not abort on exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.2
+
+* Use `Spring.failsafe_thread` to prevent threads from aborting process due to `Thread.abort_on_exception` when set to `true`
+
 ## 1.7.1
 
 * Specify absolute path to spring binfile when starting the server

--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -292,8 +292,10 @@ module Spring
       PTY.open do |master, slave|
         [STDOUT, STDERR, STDIN].each { |s| s.reopen slave }
         Thread.new {
-          Thread.current.abort_on_exception = false
-          master.read
+          begin
+            master.read
+          rescue
+          end
         }
         yield
         reset_streams

--- a/lib/spring/application_manager.rb
+++ b/lib/spring/application_manager.rb
@@ -117,6 +117,8 @@ module Spring
       Process.detach(pid)
 
       Thread.new {
+        Thread.current.abort_on_exception = false
+
         # The recv can raise an ECONNRESET, killing the thread, but that's ok
         # as if it does we're no longer interested in the child
         loop do

--- a/lib/spring/application_manager.rb
+++ b/lib/spring/application_manager.rb
@@ -117,24 +117,25 @@ module Spring
       Process.detach(pid)
 
       Thread.new {
-        Thread.current.abort_on_exception = false
-
-        # The recv can raise an ECONNRESET, killing the thread, but that's ok
-        # as if it does we're no longer interested in the child
-        loop do
-          IO.select([child])
-          break if child.recv(1, Socket::MSG_PEEK).empty?
-          sleep 0.01
-        end
-
-        log "child #{pid} shutdown"
-
-        synchronize {
-          if @pid == pid
-            @pid = nil
-            restart
+        begin
+          # The recv can raise an ECONNRESET, killing the thread, but that's ok
+          # as if it does we're no longer interested in the child
+          loop do
+            IO.select([child])
+            break if child.recv(1, Socket::MSG_PEEK).empty?
+            sleep 0.01
           end
-        }
+
+          log "child #{pid} shutdown"
+
+          synchronize {
+            if @pid == pid
+              @pid = nil
+              restart
+            end
+          }
+        rescue
+        end
       }
     end
   end

--- a/lib/spring/boot.rb
+++ b/lib/spring/boot.rb
@@ -6,3 +6,5 @@ require "spring/env"
 require "spring/process_title_updater"
 require "spring/json"
 require "spring/watcher"
+require "spring/failsafe_thread"
+

--- a/lib/spring/failsafe_thread.rb
+++ b/lib/spring/failsafe_thread.rb
@@ -1,0 +1,14 @@
+require 'thread'
+
+module Spring
+  class << self
+    def failsafe_thread
+      Thread.new {
+        begin
+          yield
+        rescue
+        end
+      }
+    end
+  end
+end

--- a/lib/spring/process_title_updater.rb
+++ b/lib/spring/process_title_updater.rb
@@ -11,6 +11,8 @@ module Spring
       updater = new(&block)
 
       Thread.new {
+        Thread.current.abort_on_exception = false
+
         $0 = updater.value
         loop { $0 = updater.next }
       }

--- a/lib/spring/process_title_updater.rb
+++ b/lib/spring/process_title_updater.rb
@@ -10,12 +10,9 @@ module Spring
     def self.run(&block)
       updater = new(&block)
 
-      Thread.new {
-        begin
-          $0 = updater.value
-          loop { $0 = updater.next }
-        rescue
-        end
+      Spring.failsafe_thread {
+        $0 = updater.value
+        loop { $0 = updater.next }
       }
     end
 

--- a/lib/spring/process_title_updater.rb
+++ b/lib/spring/process_title_updater.rb
@@ -11,10 +11,11 @@ module Spring
       updater = new(&block)
 
       Thread.new {
-        Thread.current.abort_on_exception = false
-
-        $0 = updater.value
-        loop { $0 = updater.next }
+        begin
+          $0 = updater.value
+          loop { $0 = updater.next }
+        rescue
+        end
       }
     end
 

--- a/lib/spring/server.rb
+++ b/lib/spring/server.rb
@@ -106,12 +106,7 @@ module Spring
         end
       end
 
-      @applications.values.map { |a| Thread.new {
-        begin
-          a.stop
-        rescue
-        end
-      } }.map(&:join)
+      @applications.values.map { |a| Spring.failsafe_thread { a.stop } }.map(&:join)
     end
 
     def write_pidfile

--- a/lib/spring/server.rb
+++ b/lib/spring/server.rb
@@ -107,8 +107,10 @@ module Spring
       end
 
       @applications.values.map { |a| Thread.new {
-        Thread.current.abort_on_exception = false
-        a.stop
+        begin
+          a.stop
+        rescue
+        end
       } }.map(&:join)
     end
 

--- a/lib/spring/server.rb
+++ b/lib/spring/server.rb
@@ -106,7 +106,10 @@ module Spring
         end
       end
 
-      @applications.values.map { |a| Thread.new { a.stop } }.map(&:join)
+      @applications.values.map { |a| Thread.new {
+        Thread.current.abort_on_exception = false
+        a.stop
+      } }.map(&:join)
     end
 
     def write_pidfile


### PR DESCRIPTION
This solves long outstanding issue: https://github.com/rails/spring/issues/396.

This happens, because some applications or gems do overwrite global setting of `Thread.abort_on_exception=` which is by default set to `false`.
This leads to application process to exit and making the spring unable to recover from that.

Examples of such: 
- https://github.com/alexdalitz/dnsruby/blob/master/lib/dnsruby/select_thread.rb#L27
- https://github.com/ruby-concurrency/concurrent-ruby/blob/master/lib/concurrent/thread_safe/synchronized_delegator.rb#L26
