### PR TITLE
Support AcitveSupport 5.0.0 as a dependency.

### DIFF
--- a/spring.gemspec
+++ b/spring.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.files         = Dir["LICENSE.txt", "README.md", "lib/**/*", "bin/*"]
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
 
-  gem.add_development_dependency 'activesupport', '~> 4.2.0'
+  gem.add_development_dependency 'activesupport', '>= 4.2.0', '< 6.0.0'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'bump'
 end


### PR DESCRIPTION
Hi,
Is it possible to support activesupport 5.0.0 too as a dependency?
Thanks.
