### PR TITLE
This fixes isolated unit test.

### DIFF
--- a/lib/spring/watcher/polling.rb
+++ b/lib/spring/watcher/polling.rb
@@ -1,3 +1,5 @@
+require "spring/watcher/abstract"
+
 module Spring
   module Watcher
     class Polling < Abstract


### PR DESCRIPTION
Hi,

I got below error with isolated environment (without rake).
The reason why I did this, is that I am managing your gem's RPM package on Fedora Project.
And I want to run the test without Bundler as much as possible with system installed gem files.
Below case is using bundler as "bundle exec" to explain easily.

```
$ bundle install --path vendor/bundle
$ bundle exec ruby -Ilib:test -e 'Dir.glob "./test/unit/**/*_test.rb", &method(:require)'
/home/jaruga/git/spring/lib/spring/watcher/polling.rb:3:in `<module:Watcher>': uninitialized constant Spring::Watcher::Abstract (NameError)
  from /home/jaruga/git/spring/lib/spring/watcher/polling.rb:2:in `<module:Spring>'
  from /home/jaruga/git/spring/lib/spring/watcher/polling.rb:1:in `<top (required)>'
  from /home/jaruga/git/spring/test/unit/watcher_test.rb:3:in `require'
  from /home/jaruga/git/spring/test/unit/watcher_test.rb:3:in `<top (required)>'
  from -e:1:in `require'
  from -e:1:in `glob'
  from -e:1:in `<main>'
```

I am happy that this modification is merged to the master branch.
Thanks.
