### PR TITLE
Use Bundler::LockfileParser to parse lockfile instead of regex

### DIFF
--- a/lib/spring/client/binstub.rb
+++ b/lib/spring/client/binstub.rb
@@ -23,10 +23,6 @@ CODE
       # binstub from the application process. Which means that in the application
       # process we'll execute the lines which come after the LOADER block, which
       # is what we want.
-      #
-      # Parsing the lockfile in this way is pretty nasty but reliable enough
-      # The regex ensures that the match must be between a GEM line and an empty
-      # line, so it won't go on to the next section.
       SPRING = <<'CODE'
 #!/usr/bin/env ruby
 
@@ -37,9 +33,10 @@ unless defined?(Spring)
   require 'rubygems'
   require 'bundler'
 
-  if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  if spring = lockfile.specs.detect { |spec| spec.name == "spring" }
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
-    gem 'spring', match[1]
+    gem 'spring', spring.version
     require 'spring/binstub'
   end
 end


### PR DESCRIPTION
The regex that was used to parse the lock file was not working in the case where git is configured with `core.autocrlf true`. This config changes the line endings in the lockfile to `\r\n`, causing the dollar signs in the pattern to not match.

This PR changes the parsing of the lockfile to use `Bundler::LockfileParser`.

@rafaelfranca as discussed IRL.