### PR TITLE
Kill PTY I/O thread when we are done with it

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -295,10 +295,11 @@ module Spring
     def with_pty
       PTY.open do |master, slave|
         [STDOUT, STDERR, STDIN].each { |s| s.reopen slave }
-        Thread.new { master.read }
+        reader_thread = Spring.failsafe_thread { master.read }
         begin
           yield
         ensure
+          reader_thread.kill
           reset_streams
         end
       end

--- a/lib/spring/test/acceptance_test.rb
+++ b/lib/spring/test/acceptance_test.rb
@@ -172,6 +172,14 @@ module Spring
         assert_success app.spring_test_command
       end
 
+      test "app gets reloaded even with abort_on_exception=true" do
+        assert_success app.spring_test_command
+        File.write(app.path("config/initializers/thread_config.rb"), "Thread.abort_on_exception = true")
+
+        app.await_reload
+        assert_success app.spring_test_command
+      end
+
       test "app recovers when a boot-level error is introduced" do
         config = app.application_config.read
 


### PR DESCRIPTION
Sometimes the PTY slave can be closed, causing an unhandled exception in
the thread which is calling `master.read` (socket closed).

This change kills the thread before this happens.

This solves https://github.com/rails/spring/issues/396 for the test case included
 (since this exception was causing Spring to hang)
