### PR TITLE
fix craches where session pgid is unknown #330

### DIFF
--- a/lib/spring/server.rb
+++ b/lib/spring/server.rb
@@ -81,7 +81,12 @@ module Spring
     # This will cause it to be automatically killed once the session
     # ends (i.e. when the user closes their terminal).
     def set_pgid
-      Process.setpgid(0, SID.pgid)
+      pgid = SID.pgid
+      if pgid.nil?
+        log "warn: unable to fetch process group of current session"
+        return
+      end
+      Process.setpgid(0, pgid)
     end
 
     # Ignore SIGINT and SIGQUIT otherwise the user typing ^C or ^\ on the command line

--- a/lib/spring/sid.rb
+++ b/lib/spring/sid.rb
@@ -30,13 +30,16 @@ module Spring
           fiddle_func.call(0)
         else
           # last resort: shell out
-          `ps -p #{Process.pid} -o sess=`.to_i
+          `ps -p #{Process.pid} -o sid=`.to_i
         end
       end
     end
 
     def self.pgid
-      Process.getpgid(sid)
-    end
+      begin
+        Process.getpgid(sid)
+      rescue
+      end
+     end
   end
 end

--- a/lib/spring/sid.rb
+++ b/lib/spring/sid.rb
@@ -30,7 +30,7 @@ module Spring
           fiddle_func.call(0)
         else
           # last resort: shell out
-          `ps -p #{Process.pid} -o sid=`.to_i
+          `ps -p #{Process.pid} -o sess=`.to_i
         end
       end
     end


### PR DESCRIPTION
This changes make it possible to work on some os.
It contains only pgid result checking and catch exceptions if any.

(more about problem in discussion #330)