### PR TITLE
Gracefully deal with dangling symlinks

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -66,7 +66,17 @@ module Spring
 
     def start_watcher
       @watcher = Spring.watcher
-      @watcher.on_stale { state! :watcher_stale }
+
+      @watcher.on_stale do
+        state! :watcher_stale
+      end
+
+      if @watcher.respond_to? :on_debug
+        @watcher.on_debug do |message|
+          spring_env.log "[watcher:#{app_env}] #{message}"
+        end
+      end
+
       @watcher.start
     end
 

--- a/lib/spring/watcher/abstract.rb
+++ b/lib/spring/watcher/abstract.rb
@@ -23,9 +23,21 @@ module Spring
         @directories = Set.new
         @stale       = false
         @listeners   = []
+
+        @on_debug    = nil
+      end
+
+      def on_debug(&block)
+        @on_debug = block
+      end
+
+      def debug
+        @on_debug.call(yield) if @on_debug
       end
 
       def add(*items)
+        debug { "watcher: add: #{items.inspect}" }
+
         items = items.flatten.map do |item|
           item = Pathname.new(item)
 
@@ -56,16 +68,19 @@ module Spring
       end
 
       def on_stale(&block)
+        debug { "added listener: #{block.inspect}" }
         @listeners << block
       end
 
       def mark_stale
         return if stale?
         @stale = true
+        debug { "marked stale, calling listeners: listeners=#{@listeners.inspect}" }
         @listeners.each(&:call)
       end
 
       def restart
+        debug { "restarting" }
         stop
         start
       end


### PR DESCRIPTION
Gracefully deal with dangling symlinks
* Don't add files that are dangling symlinks
* When watching a directory, ignore dangling symlinks rather than treating them as forever-stale

Add a watcher logging facility so such things can be diagnosed and debugged.