### PR TITLE
Fix binstubs not being replaced when their quoting style was changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next release
 
+* Fix binstubs not being replaced when their quoting style was changed (#534)
 * Preserve comments right after the shebang line which might include magic comments such as `frozen_string_literal: true'
 
 ## 2.0.2

--- a/lib/spring/client/binstub.rb
+++ b/lib/spring/client/binstub.rb
@@ -46,11 +46,10 @@ CODE
       OLD_BINSTUB = %{if !Process.respond_to?(:fork) || Gem::Specification.find_all_by_name("spring").empty?}
 
       BINSTUB_VARIATIONS = Regexp.union [
-        %{begin\n  load File.expand_path("../spring", __FILE__)\nrescue LoadError\nend\n},
         %{begin\n  load File.expand_path('../spring', __FILE__)\nrescue LoadError\nend\n},
         %{begin\n  spring_bin_path = File.expand_path('../spring', __FILE__)\n  load spring_bin_path\nrescue LoadError => e\n  raise unless e.message.end_with? spring_bin_path, 'spring/binstub'\nend\n},
         LOADER
-      ]
+      ].map { |binstub| /#{Regexp.escape(binstub).gsub("'", "['\"]")}/ }
 
       class Item
         attr_reader :command, :existing

--- a/lib/spring/test/acceptance_test.rb
+++ b/lib/spring/test/acceptance_test.rb
@@ -237,6 +237,9 @@ module Spring
         assert_success "#{app.spring} binstub --remove rake", stdout: "bin/rake: spring removed"
         assert !app.path("bin/rake").read.include?(Spring::Client::Binstub::LOADER)
         assert_success "bin/rake -T", stdout: "rake db:migrate"
+
+        assert_success "#{app.spring} binstub rake", stdout: "bin/rake: spring inserted"
+        assert app.path("bin/rake").read.include?(Spring::Client::Binstub::LOADER)
       end
 
       test "binstub remove all" do


### PR DESCRIPTION
I found a **bug**: _The same code is duplicatedly generated_.

# Background

I've run `rubocop -a` after `bundle exec spring binstub --all`.
And it changed to double quotes from single quotes in binstubs:

```ruby
#!/usr/bin/env ruby
begin
  load File.expand_path("../spring", __FILE__)
rescue LoadError => e
  raise unless e.message.include?("spring")
end
APP_PATH = File.expand_path("../config/application", __dir__)
require_relative "../config/boot"
require "rails/commands"
```

Then I've run `bundle exec spring binstub --all` again.

# Before

```diff
$ bundle exec spring binstub --all
* bin/rake: spring inserted # <- Oops
* bin/rails: spring inserted # <- Oops

$ git diff
diff --git a/bin/rails b/bin/rails
index 40d2d5e..7ee6e82 100755
--- a/bin/rails
+++ b/bin/rails
@@ -1,5 +1,10 @@
 #!/usr/bin/env ruby
 begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
+begin
   load File.expand_path("../spring", __FILE__)
 rescue LoadError => e
   raise unless e.message.include?("spring")
diff --git a/bin/rake b/bin/rake
index 3df5805..72f4b15 100755
--- a/bin/rake
+++ b/bin/rake
@@ -1,5 +1,10 @@
 #!/usr/bin/env ruby
 begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
+begin
   load File.expand_path("../spring", __FILE__)
 rescue LoadError => e
   raise unless e.message.include?("spring")
diff --git a/bin/spring b/bin/spring
index b44ad1a..fb2ec2e 100755
--- a/bin/spring
+++ b/bin/spring
@@ -4,14 +4,14 @@
 # It gets overwritten when you run the `spring binstub` command.

 unless defined?(Spring)
-  require "rubygems"
-  require "bundler"
+  require 'rubygems'
+  require 'bundler'

   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
   spring = lockfile.specs.detect { |spec| spec.name == "spring" }
   if spring
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
-    gem "spring", spring.version
-    require "spring/binstub"
+    gem 'spring', spring.version
+    require 'spring/binstub'
   end
 end
```

# After

```diff
$ bundle exec spring binstub --all
* bin/rake: upgraded
* bin/rails: upgraded

$ git diff
diff --git a/bin/rails b/bin/rails
index 40d2d5e..8e69e09 100755
--- a/bin/rails
+++ b/bin/rails
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 begin
-  load File.expand_path("../spring", __FILE__)
+  load File.expand_path('../spring', __FILE__)
 rescue LoadError => e
-  raise unless e.message.include?("spring")
+  raise unless e.message.include?('spring')
 end
 APP_PATH = File.expand_path("../config/application", __dir__)
 require_relative "../config/boot"
diff --git a/bin/rake b/bin/rake
index 3df5805..53da8ce 100755
--- a/bin/rake
+++ b/bin/rake
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 begin
-  load File.expand_path("../spring", __FILE__)
+  load File.expand_path('../spring', __FILE__)
 rescue LoadError => e
-  raise unless e.message.include?("spring")
+  raise unless e.message.include?('spring')
 end
 require_relative "../config/boot"
 require "rake"
diff --git a/bin/spring b/bin/spring
index b44ad1a..fb2ec2e 100755
--- a/bin/spring
+++ b/bin/spring
@@ -4,14 +4,14 @@
 # It gets overwritten when you run the `spring binstub` command.

 unless defined?(Spring)
-  require "rubygems"
-  require "bundler"
+  require 'rubygems'
+  require 'bundler'

   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
   spring = lockfile.specs.detect { |spec| spec.name == "spring" }
   if spring
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
-    gem "spring", spring.version
-    require "spring/binstub"
+    gem 'spring', spring.version
+    require 'spring/binstub'
   end
 end
```

