### PR TITLE
Specify file name where custom application root is required when using Spring with a Rails engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,8 @@ server process is started, it can be used to add new top-level commands.
 Spring must know how to find your Rails application. If you have a
 normal app everything works out of the box. If you are working on a
 project with a special setup (an engine for example), you must tell
-Spring where your app is located:
+Spring where your app is located by specifying the below code in a
+`config/spring.rb` file relative to your engines root directory :
 
 ```ruby
 Spring.application_root = './test/dummy'


### PR DESCRIPTION
**Background**:

When attempting to using Spring with a Rails engine, I wasn't quite sure in which file do I need to include `Spring.application_root = './test/dummy'` in order to use it. I found the answer after some googling around via [this link](https://github.com/rails/spring/issues/323). IMHO it could be useful to have the same info in the README so that people exactly know how to use Spring in the context of a special setup like a Rails engine.