### PR TITLE
Unify method to detect Gemfile name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix binstubs not being replaced when their quoting style was changed (#534)
 * Preserve comments right after the shebang line which might include magic comments such as `frozen_string_literal: true'
+* Added support for `gems.rb` with Gemfile file name detection using Bundler method
 
 ## 2.0.2
 

--- a/lib/spring/configuration.rb
+++ b/lib/spring/configuration.rb
@@ -5,7 +5,7 @@ module Spring
     attr_accessor :application_root, :quiet
 
     def gemfile
-      ENV['BUNDLE_GEMFILE'] || "Gemfile"
+      Bundler.default_gemfile
     end
 
     def after_fork_callbacks

--- a/lib/spring/test/application.rb
+++ b/lib/spring/test/application.rb
@@ -48,6 +48,18 @@ module Spring
         path "Gemfile"
       end
 
+      def gemfile_lock
+        path "Gemfile.lock"
+      end
+
+      def gems_rb
+        path "gems.rb"
+      end
+
+      def gems_locked
+        path "gems.locked"
+      end
+
       def gem_home
         path "../gems/#{RUBY_VERSION}"
       end


### PR DESCRIPTION
**Background**
Bundler 1.9 added support for changed Gemfile name: `gems.rb`. ([related bundler issue](https://github.com/bundler/bundler/issues/694))

Spring use Bundler method to find Gemfile in [binstub](https://github.com/rails/spring/blob/f0d2d65afd715cb0103af9e31ecfcee7f2d2c825/lib/spring/client/binstub.rb#L36) but in configuration it use [custom method](https://github.com/rails/spring/blob/85f9aa7cfbaddf135a3588b93be28e37fe02c3c0/lib/spring/configuration.rb#L7), which don't cover new Gemfile name (gems.rb).

**Pull request**
This pull request unify Gemfile name detection by using Bundler method in both places. Old behavior still works like expected and now support also gems.rb file.