### PR TITLE
CI against Ruby 2.2.8/2.3.5/2.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ rvm:
   - 1.9.3 # when removed, get rid of the before_script hack and also the one in application_generator.rb
   - 2.0.0
   - 2.1.10
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
   - ruby-head
 env:
   - RAILS_VERSION="~> 4.2.0"
@@ -30,6 +30,8 @@ matrix:
   allow_failures:
     - rvm: ruby-head
   fast_finish: true
+before_install:
+  - gem update bundler
 before_script:
   - "[ $TRAVIS_RUBY_VERSION = \"1.9.3\" ] && travis_retry gem install mime-types --version \"~> 2\" || true"
   - "[ $TRAVIS_RUBY_VERSION = \"1.9.3\" -o $TRAVIS_RUBY_VERSION = \"2.0.0\" ] && travis_retry gem install nokogiri --version \"~> 1.6.8\" || true"


### PR DESCRIPTION
This PR includes addition of `before_install: gem update bundler`.
because, with ruby-1.9.3, bundle install is failing with this error:

```
Using bundler 1.7.6
NoMethodError: undefined method `spec' for nil:NilClass
```
Details here: https://travis-ci.org/rails/spring/jobs/281611159