### PR TITLE
Do not load configuration options from `.railsrc` when generating dummy app

### DIFF
--- a/test/support/application_generator.rb
+++ b/test/support/application_generator.rb
@@ -43,9 +43,9 @@ module Spring
 
         @version = RailsVersion.new(`ruby -e 'puts Gem::Specification.find_by_name("rails", "#{version_constraint}").version'`.chomp)
 
-        skips = %w(--skip-bundle --skip-javascript --skip-sprockets --skip-spring --skip-listen --skip-system-test)
+        options = %w(--skip-bundle --skip-javascript --skip-sprockets --skip-spring --skip-listen --skip-system-test --no-rc)
 
-        system("rails _#{version}_ new #{application.root} #{skips.join(' ')}")
+        system("rails _#{version}_ new #{application.root} #{options.join(' ')}")
         raise "application generation failed" unless application.exists?
 
         FileUtils.mkdir_p(application.gem_home)


### PR DESCRIPTION
When there is for example a `~./railsrc` with `--database=postgresql`, the dummy app generated for acceptance tests will be misconfigured and the acceptance tests will error or fail.

Add the `--no-rc` option to the application generator to fix this.