### PR TITLE
Fix hangs when deleting / recreating project root with the same name

### DIFF
--- a/lib/spring/application_manager.rb
+++ b/lib/spring/application_manager.rb
@@ -34,7 +34,11 @@ module Spring
     end
 
     def alive?
-      @pid
+      return false if @pid.nil?
+      Process.getpgid(@pid)
+      true
+    rescue Errno::ESRCH
+      false
     end
 
     def with_child

--- a/lib/spring/application_manager.rb
+++ b/lib/spring/application_manager.rb
@@ -118,8 +118,18 @@ module Spring
         )
       end
 
-      start_wait_thread(pid, child) if child.gets
+      wait_for_child_to_boot
+      start_wait_thread(pid, child)
       child_socket.close
+    end
+
+    def wait_for_child_to_boot
+      timeout = 1
+      loop do
+        break if IO.select([child], nil, nil, timeout)
+        raise "child has exited unexpectedly" unless alive?
+      end
+      child.gets
     end
 
     def start_wait_thread(pid, child)

--- a/lib/spring/application_manager.rb
+++ b/lib/spring/application_manager.rb
@@ -120,6 +120,10 @@ module Spring
 
       wait_for_child_to_boot
       start_wait_thread(pid, child)
+    rescue => e
+      log "error while starting child: #{e.message}"
+      abort("error while starting child: #{e.message}")
+    ensure
       child_socket.close
     end
 

--- a/test/support/acceptance_test.rb
+++ b/test/support/acceptance_test.rb
@@ -248,6 +248,23 @@ module Spring
         assert_success app.spring_test_command
       end
 
+      test "deleting the app root should kill the server" do
+        app.run app.spring_test_command
+        assert spring_env.server_running?, "The server should be running but it isn't"
+        FileUtils.rm_rf(app.root)
+        sleep 2 # wait for the watcher to notice and react
+        assert !spring_env.server_running?, "The server should not be running but it is"
+      end
+
+      test "server restarts when the app root is deleted and recreated" do
+        assert_success app.spring_test_command
+        FileUtils.rm_rf(app.root)
+        sleep 1 # wait for the watcher to notice and react
+
+        generator.copy_to(app.root)
+        assert_success app.spring_test_command
+      end
+
       test "stop command kills server" do
         app.run app.spring_test_command
         assert spring_env.server_running?, "The server should be running but it isn't"


### PR DESCRIPTION
Fix for issue detailed in https://github.com/rails/spring/issues/396#issuecomment-345387012

If we have started a spring server, but the project root is deleted, the server can't successfully boot a child process. This is not recoverable. Even when the project is recreated, clients can also no longer communicate with the server because the socket path is derived from the project root (`Dir.pwd`) which for the server process no longer exists.

The proposed fix is to detect whenever a child cannot be started within a specific time frame - for whatever reason - rather than waiting indefinitely for the child to communicate with the `ApplicationManager` instance. This raises an error. If any error occurs when attempting to create a child process, we just abort - which shuts down the server gracefully.

This might not be a terribly common scenario, but I guess it can happen in real life - especially when people create throwaway projects to test stuff, or check out open source projects temporarily.

Fixes #247 