### PR TITLE
Fix `undefined method 'reject!' for nil:NilClass` on Ruby 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix binstubs not being replaced when their quoting style was changed (#534)
 * Preserve comments right after the shebang line which might include magic comments such as `frozen_string_literal: true'
+* Fix `undefined method 'reject!' for nil:NilClass` when using Ruby 2.5.0
 
 ## 2.0.2
 

--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -296,7 +296,7 @@ module Spring
           begin
             old_raise.call(*args)
           ensure
-            if $!
+            if $! && $!.backtrace
               lib = File.expand_path("..", __FILE__)
               $!.backtrace.reject! { |line| line.start_with?(lib) }
             end


### PR DESCRIPTION
`SystemExit#backtrace` can be `nil` on Ruby 2.5.0. Handle this case gracefully to prevent a crash.

Fixes #550 