### PR TITLE
Make `BOOT_TIMEOUT` configurable with env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 * Fix binstubs not being replaced when their quoting style was changed (#534)
 * Preserve comments right after the shebang line which might include magic comments such as `frozen_string_literal: true'
 
+## Next Release
+
+* Add env variable for BOOT_TIMEOUT
+
 ## 2.0.2
 
 * Fix reloading when a watched directory contains a dangling symlink (#522)

--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ The following environment variables are used by Spring:
 * `SPRING_SERVER_COMMAND` - The command to run to start up the spring
   server when it is not already running. Defaults to `spring _[version]_
   server --background`.
+* `SPRING_BOOT_TIMEOUT` - If set, will overwrite default boot timeout.
 
 ## Troubleshooting
 

--- a/lib/spring/client/run.rb
+++ b/lib/spring/client/run.rb
@@ -74,7 +74,7 @@ module Spring
         env.socket_path.unlink if env.socket_path.exist?
 
         pid     = Process.spawn(gem_env, env.server_command, out: File::NULL)
-        timeout = Time.now + BOOT_TIMEOUT
+        timeout = Time.now + boot_timeout
 
         @server_booted = true
 
@@ -85,7 +85,7 @@ module Spring
             exit status.exitstatus
           elsif Time.now > timeout
             $stderr.puts "Starting Spring server with `#{env.server_command}` " \
-                         "timed out after #{BOOT_TIMEOUT} seconds"
+                         "timed out after #{boot_timeout} seconds"
             exit 1
           end
 
@@ -212,6 +212,10 @@ module Spring
 
       def default_rails_env
         ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
+      end
+
+      def boot_timeout
+        ENV["SPRING_BOOT_TIMEOUT"] ? ENV["SPRING_BOOT_TIMEOUT"].to_i : BOOT_TIMEOUT
       end
     end
   end

--- a/lib/spring/test/acceptance_test.rb
+++ b/lib/spring/test/acceptance_test.rb
@@ -576,6 +576,13 @@ module Spring
         assert_failure "bin/rails runner ''", stderr: "timed out"
       end
 
+      test "server boot timeout with env variable" do
+        app.env["SPRING_SERVER_COMMAND"] = "sleep 2"
+        app.env["SPRING_BOOT_TIMEOUT"] = "1"
+
+        assert_failure "bin/rails runner ''", stderr: "timed out"
+      end
+
       test "no warnings are shown for unsprung commands" do
         app.env["DISABLE_SPRING"] = "1"
         refute_output_includes "bin/rails runner ''", stderr: "WARN"


### PR DESCRIPTION
👋 

## What:
This PR makes `BOOT_TIMEOUT` configurable thanks to the addition of the `SPRING_BOOT_TIMEOUT` environment  variable.

## Why:
We needed Spring to wait longer than 20 seconds but the time was hardcoded

## Addresses issue: https://github.com/rails/spring/issues/515


** I'd be very happy to amend the copy if not clear enough** 