### PR TITLE
Add links to rackup and rack-console command gems to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ You can add these to your Gemfile for additional commands:
 * [spring-commands-teaspoon](https://github.com/alejandrobabio/spring-commands-teaspoon.git)
 * [spring-commands-m](https://github.com/gabrieljoelc/spring-commands-m.git)
 * [spring-commands-rubocop](https://github.com/p0deje/spring-commands-rubocop)
+* [spring-commands-rackup](https://github.com/wintersolutions/spring-commands-rackup)
+* [spring-commands-rack-console](https://github.com/wintersolutions/spring-commands-rack-console)
 
 ## Use without adding to bundle
 


### PR DESCRIPTION
Add links to simple command gems for `rackup` and `rack-console` commands. Did not add to the `CHANGELOG.md` since its such a small/non-functional change.

I use both commands for development on Rails engines with the combustion gem. But there should be other use cases for them.

Thanks for the great work!