### PR TITLE
Document how to check whether Spring is running from within your code

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,24 @@ $ bin/spring stop
 Spring stopped.
 ```
 
+From within your code, you can check whether Spring is active by checking whether the
+`Spring` constant is defined:
+
+```ruby
+# With Spring running
+defined?(Spring)
+# => "constant"
+
+# With Spring disabled
+defined?(Spring)
+# => nil
+
+# Since a string is truthy and `nil` is falsy, we can use this as our condition
+if defined?(Spring)
+  # Do something
+end
+```
+
 ### Removal
 
 To remove spring:

--- a/README.md
+++ b/README.md
@@ -176,23 +176,7 @@ $ bin/spring stop
 Spring stopped.
 ```
 
-From within your code, you can check whether Spring is active by checking whether the
-`Spring` constant is defined:
-
-```ruby
-# With Spring running
-defined?(Spring)
-# => "constant"
-
-# With Spring disabled
-defined?(Spring)
-# => nil
-
-# Since a string is truthy and `nil` is falsy, we can use this as our condition
-if defined?(Spring)
-  # Do something
-end
-```
+From within your code, you can check whether Spring is active with `if defined?(Spring)`.
 
 ### Removal
 


### PR DESCRIPTION
You can check whether Spring is running by checking whether the `Spring` constant is defined.

```ruby
if defined?(Spring)
  # This code will only run if Spring is running.
end
```

This is the approach taken by Spring binary, [`bin/spring`][1].

I've often personally wanted to check whether Spring is running (e.g. when I've been seeing strange behaviour that I suspect is related to class reloading), and this is potentially useful for other gems too (e.g. to warn if environment variables might not be reflected as expected due to running through the Spring preloader).

[1]: https://github.com/rails/spring/blob/master/bin/spring#L3