### PR TITLE
Fix broken CI

### DIFF
--- a/lib/spring/test/application.rb
+++ b/lib/spring/test/application.rb
@@ -3,7 +3,7 @@ require "spring/env"
 module Spring
   module Test
     class Application
-      DEFAULT_TIMEOUT = ENV['CI'] ? 30 : 10
+      DEFAULT_TIMEOUT = ENV['CI'] ? 300 : 10
 
       attr_reader :root, :spring_env
 

--- a/lib/spring/test/application_generator.rb
+++ b/lib/spring/test/application_generator.rb
@@ -97,6 +97,10 @@ module Spring
           append_to_file(application.gemfile, "gem 'nokogiri', '~> 1.6.8'")
         end
 
+        if RUBY_VERSION < "1.9"
+          append_to_file(application.gemfile, "gem 'rake', '12.2.1'")
+        end
+
         application.bundle
 
         FileUtils.rm_rf application.path("bin")


### PR DESCRIPTION
Current our CI keeps failing.

## 1. Extend timeout

For some reason, `app.run spring_test_command` may take 100+ seconds.

```
`bundle check || bundle update --retry=2`	107.863471355
`bin/rake test /home/travis/build/mtsmfm/spring-debug/test/apps/tmp/test/controllers/posts_controller_test.rb`	105.624732034
`gem install activesupport --version '4.2.10'`	22.66985453
`bin/rails runner 'load Rails.root.join("script.rb")'`	11.518353908
`bin/rake test /home/travis/build/mtsmfm/spring-debug/test/apps/tmp/test/controllers/posts_controller_test.rb`	6.040077579
`bundle exec rails g scaffold post title:string`	4.525084902
```

https://travis-ci.org/mtsmfm/spring-debug/jobs/404996066

I got above result by applying the following patch:

```diff
diff --git a/lib/spring/test/application.rb b/lib/spring/test/application.rb
index 9a00618..93f129e 100644
--- a/lib/spring/test/application.rb
+++ b/lib/spring/test/application.rb
@@ -119,6 +119,8 @@ module Spring
         puts dump_streams(command, output) if ENV["SPRING_DEBUG"]

         @times << (Time.now - start_time) if @times
+        $times ||= []
+        $times << {command: command.to_s, time: Time.now - start_time}

         output.merge(status: status, command: command)
       rescue Timeout::Error
diff --git a/test/acceptance_test.rb b/test/acceptance_test.rb
index 665aff9..c24e82e 100644
--- a/test/acceptance_test.rb
+++ b/test/acceptance_test.rb
@@ -2,3 +2,11 @@ require_relative "helper"

 class AcceptanceTest < Spring::Test::AcceptanceTest
 end
+
+Minitest.after_run do
+  puts ?- * 100
+
+  $times.sort_by {|time| - time[:time] }.each do |time|
+    puts "`#{time[:command]}`\t#{time[:time]}"
+  end
+end
```

## 2. Use specific rake version to fix `Gem::InstallError`

12.2.1 is the last version which supports ruby 1.9.

```
  1) Error:
AcceptanceTest#test_binstub_upgrade_with_old_binstub:
RuntimeError: command failed
$ bundle check || bundle update --retry=2
--- stdout ---
Bundler can't satisfy your Gemfile's dependencies.
Install missing gems with `bundle install`.
Fetching gem metadata from http://rubygems.org/...............
Fetching gem metadata from http://rubygems.org/..
Resolving dependencies....
Fetching rake 12.3.1
Installing rake 12.3.1
Gem::InstallError: rake requires Ruby version >= 2.0.0.
An error occurred while installing rake (12.3.1), and Bundler cannot continue.
Make sure that `gem install rake -v '12.3.1' --source 'http://rubygems.org/'`
succeeds before bundling.
```

https://travis-ci.org/mtsmfm/spring-debug/jobs/404541780