### PR TITLE
Downgrade rubygems version to fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
   allow_failures:
     - rvm: ruby-head
   fast_finish: true
+before_install:
+  - gem update --system 2.6.14
 before_script:
   - "[ $TRAVIS_RUBY_VERSION = \"1.9.3\" ] && travis_retry gem install mime-types --version \"~> 2\" || true"
   - "[ $TRAVIS_RUBY_VERSION = \"1.9.3\" -o $TRAVIS_RUBY_VERSION = \"2.0.0\" ] && travis_retry gem install nokogiri --version \"~> 1.6.8\" || true"


### PR DESCRIPTION
ref: 

- https://github.com/rails/spring/pull/562
- https://github.com/rails/spring/pull/546#issuecomment-394699228

I'm looking forward the way to pass entire tests with latest rubygems though, I hope this PR can be a quick fix for our broken CI.