### PR TITLE
Update ruby, rails version for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,16 @@ rvm:
   - 1.9.3 # when removed, get rid of the before_script hack and also the one in application_generator.rb
   - 2.0.0
   - 2.1.10
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
   - ruby-head
 env:
   - RAILS_VERSION="~> 4.2.0"
   - RAILS_VERSION="~> 5.0.0"
   - RAILS_VERSION="~> 5.1.0"
+  - RAILS_VERSION="~> 5.2.0"
 matrix:
   exclude: # Rails 5 is incompatible with Ruby < 2.2.2
     - rvm: 1.9.3
@@ -27,6 +29,12 @@ matrix:
       env: RAILS_VERSION="~> 5.1.0"
     - rvm: 2.1.10
       env: RAILS_VERSION="~> 5.1.0"
+    - rvm: 1.9.3
+      env: RAILS_VERSION="~> 5.2.0"
+    - rvm: 2.0.0
+      env: RAILS_VERSION="~> 5.2.0"
+    - rvm: 2.1.10
+      env: RAILS_VERSION="~> 5.2.0"
   allow_failures:
     - rvm: ruby-head
   fast_finish: true

--- a/lib/spring/test/application_generator.rb
+++ b/lib/spring/test/application_generator.rb
@@ -48,7 +48,7 @@ module Spring
 
         @version = RailsVersion.new(`ruby -e 'puts Gem::Specification.find_by_name("rails", "#{version_constraint}").version'`.chomp)
 
-        skips = %w(--skip-bundle --skip-javascript --skip-sprockets --skip-spring)
+        skips = %w(--skip-bundle --skip-javascript --skip-sprockets --skip-spring --skip-listen --skip-system-test)
 
         system("rails _#{version}_ new #{application.root} #{skips.join(' ')}")
         raise "application generation failed" unless application.exists?


### PR DESCRIPTION
This updates the travis config for the latest ruby and rails versions.

* --skip-listen was added because travis was having intermittent failures with the Guard gem
* --skip-system-test was added because it creates a dependency on capybara in the generated app which does not resolve in a buildable way with ruby versions less than 2.3.

I don't believe either of these changes affect the utility of the test suite.