### PR TITLE
Setup "pgid" for server running in foreground mode

### DIFF
--- a/lib/spring/server.rb
+++ b/lib/spring/server.rb
@@ -36,7 +36,7 @@ module Spring
       Spring.verify_environment
 
       write_pidfile
-      set_pgid unless foreground?
+      set_pgid if foreground?
       ignore_signals unless foreground?
       set_exit_hook
       set_process_title


### PR DESCRIPTION
It's expected that `pgid` to be setup for "foreground" running server rather than for "background".

So it should be changed to `set_pgid if foreground?`

See discussion https://github.com/rails/spring/commit/e16e085e4e6aada8b32198e98e0c8ae1ab7b9963#r18804964