### PR TITLE
Set quiet mode from environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Preserve comments right after the shebang line which might include magic comments such as `frozen_string_literal: true'
 * Fix binstub failures when Bundler's `BUNDLE_APP_CONFIG` environment variable is present (#545)
 * Properly suspend and resume on ctrl-z TSTP and CONT (#361)
+* Allow quiet mode to be set by environment variable `SPRING_QUIET`
 
 ## 2.0.2
 

--- a/README.md
+++ b/README.md
@@ -404,7 +404,8 @@ The following environment variables are used by Spring:
 * `SPRING_SERVER_COMMAND` - The command to run to start up the Spring
   server when it is not already running. Defaults to `spring _[version]_
   server --background`.
-
+* `SPRING_QUIET` - If set, the "Running via Spring preloader" message will not
+  be shown each time a command runs (takes precedence over `Spring.quiet`).
 ## Troubleshooting
 
 If you want to get more information about what Spring is doing, you can

--- a/lib/spring/configuration.rb
+++ b/lib/spring/configuration.rb
@@ -2,7 +2,8 @@ require "spring/errors"
 
 module Spring
   class << self
-    attr_accessor :application_root, :quiet
+    attr_accessor :application_root
+    attr_writer :quiet
 
     def gemfile
       ENV['BUNDLE_GEMFILE'] || "Gemfile"
@@ -14,6 +15,10 @@ module Spring
 
     def after_fork(&block)
       after_fork_callbacks << block
+    end
+
+    def quiet
+      @quiet || ENV.key?('SPRING_QUIET')
     end
 
     def verify_environment

--- a/lib/spring/test/acceptance_test.rb
+++ b/lib/spring/test/acceptance_test.rb
@@ -117,6 +117,12 @@ module Spring
         refute_output_includes "bin/rails runner ''", stderr: 'Running via Spring preloader in process'
       end
 
+      test "configures quiet mode from environment" do
+        app.env['SPRING_QUIET'] = '1'
+        assert_success "bin/rails runner ''"
+        refute_output_includes "bin/rails runner ''", stderr: 'Running via Spring preloader in process'
+      end
+
       test "test changes are picked up" do
         assert_speedup do
           assert_success app.spring_test_command, stdout: "0 failures"


### PR DESCRIPTION
If `SPRING_QUIET` is set, do not display message each time a command is
run. This takes precedence over `Spring.quiet`.

Rationale:

I tend to use a `Makefile` for various orchestration commands (such as calling a number of `rake` commands). The tailored output from these commands gets a bit clobbered by Spring's `"Running via Spring preloader in process"` message (often appearing multiple times for one `make` command).

If I can prefix my `make` commands with `SPRING_QUIET=1` then things will work a lot more nicely.