### PR TITLE
Allow users of custom Gemfiles to spawn properly configured preloaded children

### DIFF
--- a/lib/spring/application_manager.rb
+++ b/lib/spring/application_manager.rb
@@ -92,11 +92,15 @@ module Spring
     def start_child(preload = false)
       @child, child_socket = UNIXSocket.pair
 
+      # If the user has specified a custom Gemfile, we must propogate that down
+      # into the preloaded runner's environment
+      gemfile = ENV['BUNDLE_GEMFILE']
       Bundler.with_original_env do
         @pid = Process.spawn(
           {
             "RAILS_ENV"           => app_env,
             "RACK_ENV"            => app_env,
+            "BUNDLE_GEMFILE"      => gemfile,
             "SPRING_ORIGINAL_ENV" => JSON.dump(Spring::ORIGINAL_ENV),
             "SPRING_PRELOAD"      => preload ? "1" : "0"
           },


### PR DESCRIPTION
`Bundle.with_clean_env` will purge `BUNDLE_GEMFILE` which will cause preloaded
children processes to come up without the proper environment variables necessary
to run for applications which use them.

Otherwise, the following would happen when a client connections:

```
/usr/local/bundle/gems/spring-2.0.2/lib/spring/configuration.rb:46:in `find_project_root': Spring::UnknownProject (Spring::UnknownProject)
        from /usr/local/bundle/gems/spring-2.0.2/lib/spring/configuration.rb:48:in `find_project_root'
        from /usr/local/bundle/gems/spring-2.0.2/lib/spring/configuration.rb:48:in `find_project_root'
        from /usr/local/bundle/gems/spring-2.0.2/lib/spring/configuration.rb:48:in `find_project_root'
        from /usr/local/bundle/gems/spring-2.0.2/lib/spring/configuration.rb:48:in `find_project_root'
        from /usr/local/bundle/gems/spring-2.0.2/lib/spring/configuration.rb:48:in `find_project_root'
        from /usr/local/bundle/gems/spring-2.0.2/lib/spring/configuration.rb:48:in `find_project_root'
        from /usr/local/bundle/gems/spring-2.0.2/lib/spring/configuration.rb:37:in `project_root_path'
        from /usr/local/bundle/gems/spring-2.0.2/lib/spring/configuration.rb:28:in `application_root_path'
        from /usr/local/bundle/gems/spring-2.0.2/lib/spring/application.rb:273:in `loaded_application_features'
        from /usr/local/bundle/gems/spring-2.0.2/lib/spring/application.rb:115:in `ensure in preload'
        from /usr/local/bundle/gems/spring-2.0.2/lib/spring/application.rb:122:in `preload'
        from /usr/local/bundle/gems/spring-2.0.2/lib/spring/application.rb:153:in `serve'
        from /usr/local/bundle/gems/spring-2.0.2/lib/spring/application.rb:141:in `block in run'
        from /usr/local/bundle/gems/spring-2.0.2/lib/spring/application.rb:135:in `loop'
        from /usr/local/bundle/gems/spring-2.0.2/lib/spring/application.rb:135:in `run'
        from /usr/local/bundle/gems/spring-2.0.2/lib/spring/application/boot.rb:19:in `<top (required)>'
        from /usr/local/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /usr/local/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from -e:1:in `<main>'
```