### PR TITLE
CI: Try having a specific sqlite3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gemspec
 if ENV["RAILS_VERSION"]
   gem "activesupport", ENV["RAILS_VERSION"]
 end
+gem "sqlite3", "1.3.13"


### PR DESCRIPTION
This WIP PR is about **choosing an exact version of sqlite3 gem**, to be able to install Rails < 6.

See https://github.com/DataDog/dd-trace-rb/pull/685 for an example of this.

Rails issue: https://github.com/rails/rails/issues/35161

## Details

This change **does not fix** the Issue.

Here's someone else, who managed to fix theirs:
https://github.com/thoughtbot/factory_bot_rails/pull/318/files

## Observations

**Ruby 2.1:10:**
ERROR:  Error installing rails:
	nokogiri requires Ruby version >= 2.3.0.

**Ruby.2.2:10**
ERROR:  Error installing rails:
	i18n requires Ruby version >= 2.3.0.
