### PR TITLE
Add support for gems.rb and gems.locked, closes #524.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * Preserve comments right after the shebang line which might include magic comments such as `frozen_string_literal: true`
 * Fix binstub failures when Bundler's `BUNDLE_APP_CONFIG` environment variable is present (#545)
 * Properly suspend and resume on ctrl-z TSTP and CONT (#361)
+* Added support for `gems.rb` with Gemfile file name detection using Bundler
+  method (#524)
+
+  *Michał Zalewski*, *JuPlutonic*
 
 ## 2.0.2
 

--- a/lib/spring/configuration.rb
+++ b/lib/spring/configuration.rb
@@ -5,7 +5,11 @@ module Spring
     attr_accessor :application_root, :quiet
 
     def gemfile
-      ENV['BUNDLE_GEMFILE'] || "Gemfile"
+      if /\s1.9.[0-9]/ ===  Bundler.ruby_scope.gsub(/[\/\s]+/,'')
+        ENV["BUNDLE_GEMFILE"] || "Gemfile"
+      else
+        Bundler.default_gemfile
+      end
     end
 
     def after_fork_callbacks

--- a/test/support/acceptance_test.rb
+++ b/test/support/acceptance_test.rb
@@ -503,6 +503,20 @@ module Spring
         assert_failure %(bin/rails runner 'require "sqlite3"'), stderr: "sqlite3"
       end
 
+      if RUBY_VERSION >= "2.0.0"
+        test "changing the gems.rb works" do
+          FileUtils.mv(app.gemfile, app.gems_rb)
+          FileUtils.mv(app.gemfile_lock, app.gems_locked)
+
+          assert_success %(bin/rails runner 'require "sqlite3"')
+
+          File.write(app.gems_rb, app.gems_rb.read.sub(%{gem 'sqlite3'}, %{# gem 'sqlite3'}))
+          app.await_reload
+
+          assert_failure %(bin/rails runner 'require "sqlite3"'), stderr: "sqlite3"
+        end
+      end
+
       test "changing the Gemfile works when Spring calls into itself" do
         File.write(app.path("script.rb"), <<-RUBY.strip_heredoc)
           gemfile = Rails.root.join("Gemfile")
@@ -515,6 +529,25 @@ module Spring
         RUBY
 
         assert_success [%(bin/rails runner 'load Rails.root.join("script.rb")'), timeout: 60]
+      end
+
+      if RUBY_VERSION >= "2.0.0"
+        test "changing the gems.rb works when spring calls into itself" do
+          FileUtils.mv(app.gemfile, app.gems_rb)
+          FileUtils.mv(app.gemfile_lock, app.gems_locked)
+
+          File.write(app.path("script.rb"), <<-RUBY.strip_heredoc)
+            gemfile = Rails.root.join("gems.rb")
+            File.write(gemfile, "\#{gemfile.read}gem 'text'\\n")
+            Bundler.with_clean_env do
+              system(#{app.env.inspect}, "bundle install")
+            end
+            output = `\#{Rails.root.join('bin/rails')} runner 'require "text"; puts "done";'`
+            exit output.include? "done\n"
+          RUBY
+
+          assert_success [%(bin/rails runner 'load Rails.root.join("script.rb")'), timeout: 60]
+        end
       end
 
       test "changing the environment between runs" do

--- a/test/support/application.rb
+++ b/test/support/application.rb
@@ -48,6 +48,18 @@ module Spring
         path "Gemfile"
       end
 
+      def gemfile_lock
+        path "Gemfile.lock"
+      end
+
+      def gems_rb
+        path "gems.rb"
+      end
+
+      def gems_locked
+        path "gems.locked"
+      end
+
       def gem_home
         path "../gems/#{RUBY_VERSION}"
       end


### PR DESCRIPTION
This pull request merges together @mizalewski's and @JuPlutonic's changes on #538 to support `gems.rb` and `gems.locked` files in spring. I've also wrapped the tests to only run on Ruby 2.0.0 or higher. Let me know if anything else is needed, thanks!