### PR TITLE
Test with Rails 6.0.0 rc1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - RAILS_VERSION="~> 5.0.0"
   - RAILS_VERSION="~> 5.1.0"
   - RAILS_VERSION="~> 5.2.0"
-  - RAILS_VERSION="~> 6.0.0.beta1"
+  - RAILS_VERSION="~> 6.0.0.rc1"
 matrix:
   exclude:
     - rvm: 2.4.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 matrix:
   exclude:
     - rvm: 2.4.6
-      env: RAILS_VERSION="~> 6.0.0.beta1"
+      env: RAILS_VERSION="~> 6.0.0.rc1"
     - rvm: 2.6.3
       env: RAILS_VERSION="~> 4.2.0"
   allow_failures:


### PR DESCRIPTION
Rails Release candidate was released almost 2 months ago why not test against that version?