### PR TITLE
Avoid -I rubylibdir with default-gem bundler

### DIFF
--- a/lib/spring/application_manager.rb
+++ b/lib/spring/application_manager.rb
@@ -94,6 +94,7 @@ module Spring
       @child, child_socket = UNIXSocket.pair
 
       Bundler.with_original_env do
+        bundler_dir = File.expand_path("../..", $LOADED_FEATURES.grep(/bundler\/setup\.rb$/).first)
         @pid = Process.spawn(
           {
             "RAILS_ENV"           => app_env,
@@ -102,7 +103,7 @@ module Spring
             "SPRING_PRELOAD"      => preload ? "1" : "0"
           },
           "ruby",
-          "-I", File.expand_path("../..", $LOADED_FEATURES.grep(/bundler\/setup\.rb$/).first),
+          *(bundler_dir != RbConfig::CONFIG["rubylibdir"] ? ["-I", bundler_dir] : []),
           "-I", File.expand_path("../..", __FILE__),
           "-e", "require 'spring/application/boot'",
           3 => child_socket,


### PR DESCRIPTION
Since Ruby 2.6.0, bundler.gem has been a default gem. It means that `$LOADED_FEATURES.grep(/bundler\/setup\.rb$/).first` could be the same as `RbConfig::CONFIG["rubylibdir"]`, which is the default gem directory and not dedicated for a specific bundler version, if no newer bundler were manually installed.

Passing default gem directory with `-I` is really problematic because it has other default gems like json.gem, and `-I` is prioritized more than `$LOAD_PATH`s added by `Bundler.require`. Using default-gem Bundler could cause a wrong default gem version on `spring server` process.