### PR TITLE
Added information about the spring-commands-parallel-tests gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ You can add these to your Gemfile for additional commands:
 * [spring-commands-testunit](https://github.com/jonleighton/spring-commands-testunit) - useful for
   running `Test::Unit` tests on Rails 3, since only Rails 4 allows you
   to use `rake test path/to/test` to run a particular test/directory.
+* [spring-commands-parallel-tests](https://github.com/DocSpring/spring-commands-parallel-tests) - Adds the `parallel_*` commands from [`parallel_tests`](https://github.com/grosser/parallel_tests).
 * [spring-commands-teaspoon](https://github.com/alejandrobabio/spring-commands-teaspoon.git)
 * [spring-commands-m](https://github.com/gabrieljoelc/spring-commands-m.git)
 * [spring-commands-rubocop](https://github.com/p0deje/spring-commands-rubocop)


### PR DESCRIPTION
I've pushed a `spring-commands-parallel-tests` gem that adds the following commands from the [`parallel_tests`](https://github.com/grosser/parallel_tests) gem to Spring:

* `parallel_test`
* `parallel_rspec`
* `parallel_cucumber`
* `parallel_spinach`

The gem also automatically applies [this patch](https://github.com/grosser/parallel_tests/wiki/Spring), so that you can use the `<%= ENV['TEST_ENV_NUMBER'] %>` in `database.yml`. It also [force-enables Spring](https://github.com/grosser/parallel_tests/pull/469) since `parallel_tests` sets `DISABLE_SPRING=1` by default.