### PR TITLE
Add link to spring-commands-standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next Release
+
+* Add link to [spring-commands-standard](https://github.com/lakim/spring-commands-standard) in README
+
 ## 2.1.0
 
 * Add explicit support for Rails 6 (no changes were needed)

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ You can add these to your Gemfile for additional commands:
 * [spring-commands-rubocop](https://github.com/p0deje/spring-commands-rubocop)
 * [spring-commands-rackup](https://github.com/wintersolutions/spring-commands-rackup)
 * [spring-commands-rack-console](https://github.com/wintersolutions/spring-commands-rack-console)
+* [spring-commands-standard](https://github.com/lakim/spring-commands-standard)
 
 ## Use without adding to bundle
 


### PR DESCRIPTION
Hello,

I created [spring-commands-standard](https://github.com/lakim/spring-commands-standard) to support the [Standard](https://github.com/testdouble/standard) gem.
Updated the documentation to link to it.

See the PR to update Standard's README: https://github.com/testdouble/standard/pull/165
