### PR TITLE
Lazily load fileutils and tmpdir

### DIFF
--- a/lib/spring/env.rb
+++ b/lib/spring/env.rb
@@ -1,7 +1,5 @@
 require "pathname"
-require "fileutils"
 require "digest/md5"
-require "tmpdir"
 
 require "spring/version"
 require "spring/sid"
@@ -33,10 +31,12 @@ module Spring
     end
 
     def tmp_path
+      require "tmpdir"
       path = Pathname.new(
         ENV["SPRING_TMP_PATH"] ||
           File.join(ENV['XDG_RUNTIME_DIR'] || Dir.tmpdir, "spring-#{Process.uid}")
       )
+      require "fileutils"
       FileUtils.mkdir_p(path) unless path.exist?
       path
     end


### PR DESCRIPTION
This change removes some fileutils redefintion warnings that happen when you boot a `rails` application that uses `spring` on a system with a default `fileutils` version, and a higher version of the `fileutils` gem available as well. This can happen, for example, on ruby 2.6.

Repro instructions are here: https://github.com/ruby/fileutils/issues/22#issuecomment-616215937.

The short explanation of why this happens is that `spring` loads without using `bundler`, so the fileutils `require` uses rubygems version of `Kernel.require` which automatically activates the latest version of the corresponding gem if a `require` argument matches a default gem (like `fileutils`). Then `rails` itself also requires `fileutils`, but at that point `bundler` is already loaded, and `bundler` does not change `Kernel.require` at all, hence the default version of `fileutils` is chosen this time.

By lazily loading `fileutils`, we make sure that `bundler` is always loaded before `fileutils`, and thus the version that ends up being required is consistent.

The explanation of why also lazily loading `tmpdir` is because `tmpdir` also loads `fileutils`. 