### PR TITLE
Remove support for old Rails versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 2.6.3
   - ruby-head
 env:
-  - RAILS_VERSION="~> 5.0.0"
   - RAILS_VERSION="~> 5.1.0"
   - RAILS_VERSION="~> 5.2.0"
   - RAILS_VERSION="~> 6.0.0.rc1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 2.6.3
   - ruby-head
 env:
-  - RAILS_VERSION="~> 4.2.0"
   - RAILS_VERSION="~> 5.0.0"
   - RAILS_VERSION="~> 5.1.0"
   - RAILS_VERSION="~> 5.2.0"
@@ -15,8 +14,6 @@ matrix:
   exclude:
     - rvm: 2.4.6
       env: RAILS_VERSION="~> 6.0.0.rc1"
-    - rvm: 2.6.3
-      env: RAILS_VERSION="~> 4.2.0"
   allow_failures:
     - rvm: ruby-head
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 2.6.3
   - ruby-head
 env:
-  - RAILS_VERSION="~> 5.1.0"
   - RAILS_VERSION="~> 5.2.0"
   - RAILS_VERSION="~> 6.0.0.rc1"
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.4.6
   - 2.5.5
   - 2.6.3
   - ruby-head
@@ -9,9 +8,6 @@ env:
   - RAILS_VERSION="~> 5.2.0"
   - RAILS_VERSION="~> 6.0.0.rc1"
 matrix:
-  exclude:
-    - rvm: 2.4.6
-      env: RAILS_VERSION="~> 6.0.0.rc1"
   allow_failures:
     - rvm: ruby-head
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ boot it every time you run a test, rake task or migration.
 
 ## Compatibility
 
-* Ruby versions: MRI 2.4, MRI 2.5, MRI 2.6
+* Ruby versions: MRI 2.5, MRI 2.6
 * Rails versions: 5.2, 6.0 (Spring is installed by default when you do
   `rails new` to generate your application)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ boot it every time you run a test, rake task or migration.
 ## Compatibility
 
 * Ruby versions: MRI 2.4, MRI 2.5, MRI 2.6
-* Rails versions: 5.1, 5.2, 6.0 (Spring is installed by default when you do
+* Rails versions: 5.2, 6.0 (Spring is installed by default when you do
   `rails new` to generate your application)
 
 Spring makes extensive use of `Process.fork`, so won't be able to

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ boot it every time you run a test, rake task or migration.
 ## Compatibility
 
 * Ruby versions: MRI 2.4, MRI 2.5, MRI 2.6
-* Rails versions: 5.0, 5.1, 5.2, 6.0 (Spring is installed by default when you do
+* Rails versions: 5.1, 5.2, 6.0 (Spring is installed by default when you do
   `rails new` to generate your application)
 
 Spring makes extensive use of `Process.fork`, so won't be able to

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ boot it every time you run a test, rake task or migration.
 ## Compatibility
 
 * Ruby versions: MRI 2.4, MRI 2.5, MRI 2.6
-* Rails versions: 4.2, 5.0, 5.1, 5.2, 6.0 (Spring is installed by default when you do
+* Rails versions: 5.0, 5.1, 5.2, 6.0 (Spring is installed by default when you do
   `rails new` to generate your application)
 
 Spring makes extensive use of `Process.fork`, so won't be able to

--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -91,8 +91,8 @@ module Spring
 
       require Spring.application_root_path.join("config", "application")
 
-      unless Rails.respond_to?(:gem_version) && Rails.gem_version >= Gem::Version.new('5.0.0')
-        raise "Spring only supports Rails >= 5.0.0"
+      unless Rails.respond_to?(:gem_version) && Rails.gem_version >= Gem::Version.new('5.1.0')
+        raise "Spring only supports Rails >= 5.1.0"
       end
 
       # config/environments/test.rb will have config.cache_classes = true. However

--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -91,8 +91,8 @@ module Spring
 
       require Spring.application_root_path.join("config", "application")
 
-      unless Rails.respond_to?(:gem_version) && Rails.gem_version >= Gem::Version.new('4.2.0')
-        raise "Spring only supports Rails >= 4.2.0"
+      unless Rails.respond_to?(:gem_version) && Rails.gem_version >= Gem::Version.new('5.0.0')
+        raise "Spring only supports Rails >= 5.0.0"
       end
 
       # config/environments/test.rb will have config.cache_classes = true. However

--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -91,8 +91,8 @@ module Spring
 
       require Spring.application_root_path.join("config", "application")
 
-      unless Rails.respond_to?(:gem_version) && Rails.gem_version >= Gem::Version.new('5.1.0')
-        raise "Spring only supports Rails >= 5.1.0"
+      unless Rails.respond_to?(:gem_version) && Rails.gem_version >= Gem::Version.new('5.2.0')
+        raise "Spring only supports Rails >= 5.2.0"
       end
 
       # config/environments/test.rb will have config.cache_classes = true. However
@@ -163,13 +163,7 @@ module Spring
       setup command
 
       if Rails.application.reloaders.any?(&:updated?)
-        # Rails 5.1 forward-compat. AD::R is deprecated to AS::R in Rails 5.
-        if defined? ActiveSupport::Reloader
-          Rails.application.reloader.reload!
-        else
-          ActionDispatch::Reloader.cleanup!
-          ActionDispatch::Reloader.prepare!
-        end
+        Rails.application.reloader.reload!
       end
 
       pid = fork {

--- a/spring.gemspec
+++ b/spring.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.files         = Dir["LICENSE.txt", "README.md", "lib/**/*", "bin/*"]
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
 
-  gem.required_ruby_version = ">= 2.4.0"
+  gem.required_ruby_version = ">= 2.5.0"
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'bump'

--- a/test/support/acceptance_test.rb
+++ b/test/support/acceptance_test.rb
@@ -12,7 +12,7 @@ module Spring
       DEFAULT_SPEEDUP = 0.8
 
       def rails_version
-        ENV['RAILS_VERSION'] || '~> 5.0.0'
+        ENV['RAILS_VERSION'] || '~> 6.0.0'
       end
 
       # Extension point for spring-watchers-listen

--- a/test/support/acceptance_test.rb
+++ b/test/support/acceptance_test.rb
@@ -503,18 +503,16 @@ module Spring
         assert_failure %(bin/rails runner 'require "sqlite3"'), stderr: "sqlite3"
       end
 
-      if RUBY_VERSION >= "2.0.0"
-        test "changing the gems.rb works" do
-          FileUtils.mv(app.gemfile, app.gems_rb)
-          FileUtils.mv(app.gemfile_lock, app.gems_locked)
+      test "changing the gems.rb works" do
+        FileUtils.mv(app.gemfile, app.gems_rb)
+        FileUtils.mv(app.gemfile_lock, app.gems_locked)
 
-          assert_success %(bin/rails runner 'require "sqlite3"')
+        assert_success %(bin/rails runner 'require "sqlite3"')
 
-          File.write(app.gems_rb, app.gems_rb.read.sub(%{gem 'sqlite3'}, %{# gem 'sqlite3'}))
-          app.await_reload
+        File.write(app.gems_rb, app.gems_rb.read.sub(%{gem 'sqlite3'}, %{# gem 'sqlite3'}))
+        app.await_reload
 
-          assert_failure %(bin/rails runner 'require "sqlite3"'), stderr: "sqlite3"
-        end
+        assert_failure %(bin/rails runner 'require "sqlite3"'), stderr: "sqlite3"
       end
 
       test "changing the Gemfile works when Spring calls into itself" do
@@ -531,23 +529,21 @@ module Spring
         assert_success [%(bin/rails runner 'load Rails.root.join("script.rb")'), timeout: 60]
       end
 
-      if RUBY_VERSION >= "2.0.0"
-        test "changing the gems.rb works when spring calls into itself" do
-          FileUtils.mv(app.gemfile, app.gems_rb)
-          FileUtils.mv(app.gemfile_lock, app.gems_locked)
+      test "changing the gems.rb works when spring calls into itself" do
+        FileUtils.mv(app.gemfile, app.gems_rb)
+        FileUtils.mv(app.gemfile_lock, app.gems_locked)
 
-          File.write(app.path("script.rb"), <<-RUBY.strip_heredoc)
-            gemfile = Rails.root.join("gems.rb")
-            File.write(gemfile, "\#{gemfile.read}gem 'text'\\n")
-            Bundler.with_clean_env do
-              system(#{app.env.inspect}, "bundle install")
-            end
-            output = `\#{Rails.root.join('bin/rails')} runner 'require "text"; puts "done";'`
-            exit output.include? "done\n"
-          RUBY
+        File.write(app.path("script.rb"), <<-RUBY.strip_heredoc)
+          gemfile = Rails.root.join("gems.rb")
+          File.write(gemfile, "\#{gemfile.read}gem 'text'\\n")
+          Bundler.with_clean_env do
+            system(#{app.env.inspect}, "bundle install")
+          end
+          output = `\#{Rails.root.join('bin/rails')} runner 'require "text"; puts "done";'`
+          exit output.include? "done\n"
+        RUBY
 
-          assert_success [%(bin/rails runner 'load Rails.root.join("script.rb")'), timeout: 60]
-        end
+        assert_success [%(bin/rails runner 'load Rails.root.join("script.rb")'), timeout: 60]
       end
 
       test "changing the environment between runs" do


### PR DESCRIPTION
I noticed several CI failures on #616. Since all of them happen on Rails versions no longer maintain, I think that's a good sign that it's time to drop support. 