### PR TITLE
Redirect STDERR to /dev/null during eager_preload

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -115,7 +115,12 @@ module Spring
     end
 
     def eager_preload
-      with_pty { preload }
+      with_pty do
+        # we can't see stderr and there could be issues when it's overflown
+        # see https://github.com/rails/spring/issues/396
+        STDERR.reopen("/dev/null")
+        preload
+      end
     end
 
     def run


### PR DESCRIPTION
**Note: This is not from my own fork, nor my own work!**

Fixes #396 (for me at least)