### PR TITLE
Fixed the deprecation warning with deployment tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,12 +188,13 @@ To remove Spring:
 ### Deployment
 
 You must not install Spring on your production environment. To prevent it from
-being installed, provide the `--without development test` argument to the
+being installed, run the `bundle config set without 'development test'` before
 `bundle install` command which is used to install gems on your production
 machines:
 
 ```
-$ bundle install --without development test
+$ bundle config set without 'development test'
+$ bundle install
 ```
 
 ## Commands


### PR DESCRIPTION
When deploying the Ruby On Rails Application, tried with the command `bundle install --without development test` it is showing a warning saying like `[DEPRECATED] The `--without` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set without 'development test'`, and stop using this flag` .This PR is to fix the line in the readme.md. Please discard if it is not valuable.
