### PR TITLE
Start Spring server process in directory where command was called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next Release
+
+* Start server process in directory where command was called
+
 ## 2.1.0
 
 * Add explicit support for Rails 6 (no changes were needed)

--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -172,6 +172,11 @@ module Spring
         end
       end
 
+      # Ensure we boot the process in the directory the command was called from,
+      # not from the directory Spring started in
+      original_dir = Dir.pwd
+      Dir.chdir(env['PWD'] || original_dir)
+
       pid = fork {
         Process.setsid
         IGNORE_SIGNALS.each { |sig| trap(sig, "DEFAULT") }
@@ -237,6 +242,7 @@ module Spring
       # (i.e. to prevent `spring rake -T | grep db` from hanging forever),
       # even when exception is raised before forking (i.e. preloading).
       reset_streams
+      Dir.chdir(original_dir)
     end
 
     def terminate


### PR DESCRIPTION
When a Spring server boots, it maintains its directory
for the duration of its life-cycle. This means that if you've changed
directories and run a Spring command, the process will start within the
context of the original directory.

This is problematic in the use case of engines, where an engine command
may be run from the context of the host application, and then run again
from the engine directory. In this scenario, the process will assume its
working directory is the host application instead of the engine.

The solution proposed here is to change the current directory to where
the Spring command was called from. The directory is taken from `ENV['PWD']`

STEPS TO REPRODUCE:
1) `bin/rails test engines/foo` in main application => correctly runs the `engines/foo` test suite
2) `cd engines/foo; bin/rails test` => runs the main application tests, and `Dir.pwd` in the rails binstubs is the main application
