### PR TITLE
Ensure bundler is required when used

### DIFF
--- a/lib/spring/configuration.rb
+++ b/lib/spring/configuration.rb
@@ -1,4 +1,5 @@
 require "spring/errors"
+require "bundler"
 
 module Spring
   class << self


### PR DESCRIPTION
`Spring.gemfile` is using bundler, the require is needed in certain cases in which Bundler is not already loaded.

Specifically when spring is loaded via `Spring::ApplicationManager` the `#start_child` method wraps the call inside `Bundler.with_original_env` restoring a `RUBYOPT` env variable without the bundler require. That, in turn, causes errors like:

    /Users/elia/.asdf/installs/ruby/2.7.1/lib/ruby/gems/2.7.0/gems/spring-2.1.1/lib/spring/configuration.rb:10:in `gemfile': uninitialized constant #<Class:Spring>::Bundler (NameError)

Fixes #624 