### PR TITLE
Sequel support

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -291,6 +291,7 @@ module Spring
 
     def disconnect_database
       ActiveRecord::Base.remove_connection if active_record_configured?
+      Sequel::DATABASES.each(&:disconnect) if sequel_configured?
     end
 
     def connect_database
@@ -374,6 +375,10 @@ module Spring
 
     def active_record_configured?
       defined?(ActiveRecord::Base) && ActiveRecord::Base.configurations.any?
+    end
+
+    def sequel_configured?
+      defined?(Sequel)
     end
   end
 end


### PR DESCRIPTION
Like Active Record, Sequel also requires the database connection to be closed before forking. To make Sequel integrate better with Rails out-of-the-box, this PR adds Sequel support to Spring. We don't need to do anything in `#connect_database`, as Sequel will automatically establish a new connection on first query (just like Active Record).
