### PR TITLE
Revert "Start server process in dir where cmd was called"

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -172,11 +172,6 @@ module Spring
         end
       end
 
-      # Ensure we boot the process in the directory the command was called from,
-      # not from the directory Spring started in
-      original_dir = Dir.pwd
-      Dir.chdir(env['PWD'] || original_dir)
-
       pid = fork {
         Process.setsid
         IGNORE_SIGNALS.each { |sig| trap(sig, "DEFAULT") }
@@ -242,7 +237,6 @@ module Spring
       # (i.e. to prevent `spring rake -T | grep db` from hanging forever),
       # even when exception is raised before forking (i.e. preloading).
       reset_streams
-      Dir.chdir(original_dir)
     end
 
     def terminate


### PR DESCRIPTION
This reverts commit 20d3a5f03e0e758a887cfa95d63c0af185d79341.

As discussed with Adrianna, it was never expected that these changes broke existing specs, but we recently found out that they did. Until an alternative solution that doesn't break exisiting specs is found, we agreed on reverting the changes.