### PR TITLE
Fix acceptance test for under rails 5.1

### DIFF
--- a/test/support/acceptance_test.rb
+++ b/test/support/acceptance_test.rb
@@ -510,7 +510,7 @@ module Spring
 
           assert_success %(bin/rails runner 'require "sqlite3"')
 
-          File.write(app.gems_rb, app.gems_rb.read.sub(%{gem 'sqlite3'}, %{# gem 'sqlite3'}))
+          File.write(app.gems_rb, app.gems_rb.read.gsub(%{gem 'sqlite3'}, %{# gem 'sqlite3'}))
           app.await_reload
 
           assert_failure %(bin/rails runner 'require "sqlite3"'), stderr: "sqlite3"

--- a/test/support/application_generator.rb
+++ b/test/support/application_generator.rb
@@ -59,14 +59,10 @@ module Spring
           c.gsub!(/(gem '(byebug|web-console|sdoc|jbuilder)')/, "# \\1")
 
           if @version.to_s < '5.2'
-            c.gsub!(/(gem 'sqlite3')/, "# \\1")
+            c.gsub!(/(gem 'sqlite3')/, "\\1, '< 1.4'")
           end
 
           c
-        end
-
-        if @version.to_s < '5.2'
-          append_to_file(application.gemfile, "gem 'sqlite3', '< 1.4'")
         end
 
         rewrite_file(application.path("config/environments/test.rb")) do |c|

--- a/test/support/application_generator.rb
+++ b/test/support/application_generator.rb
@@ -59,7 +59,7 @@ module Spring
           c.gsub!(/(gem '(byebug|web-console|sdoc|jbuilder)')/, "# \\1")
 
           if @version.to_s < '5.2'
-            c.gsub!(/(gem 'sqlite3')/, "\\1, '< 1.4'")
+            c.gsub!(/(gem 'sqlite3').*$/, "\\1, '< 1.4'")
           end
 
           c


### PR DESCRIPTION
| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/9955/97068543-5d3e2980-1603-11eb-8e53-e8855908637c.png) | ![image](https://user-images.githubusercontent.com/9955/97068548-64fdce00-1603-11eb-942c-dff38a8f099d.png) |

# Why
- Acceptance test is failed with under Rails 5.1.0 because the Gemfile has [multiple `gem 'sqlite3'` line](https://github.com/rails/spring/blob/a85d32ef3726931b2b81abbb10a6e1c2964e7e32/test/support/application_generator.rb#L61-L70).
- But the test [replace only one line of `gem 'sqlite3'`](https://github.com/rails/spring/blob/a85d32ef3726931b2b81abbb10a6e1c2964e7e32/test/support/acceptance_test.rb#L144) for `gems.rb` changing test.

# What
- Ensure 1 line of `gem 'sqlite3'` . ( [commit](https://github.com/rails/spring/pull/630/commits/fdf0f8b21552f19ded444123a174920e93bad822) )
- Use `gsub` to comment out `gem sqlite3'` .

# Other fails
- <del>`LoadError: cannot load such file -- bump/tasks` </del>
  - Meregd 🎉 fix at https://github.com/rails/spring/pull/629 
- not acceptance test
  - `sprockets requires Ruby version >= 2.5.0. The current ruby version is 2.4.6.354.`
    - Officially support Ruby 2.4.x ?
  - `ArgumentError: wrong number of arguments (given 2, expected 1)` ([here](https://github.com/rails/spring/blob/d7b21ff9afcaf1f5904b7a2286e2a8201728cb54/test/support/watcher_test.rb#L36))
    - [Keyword arguments are now separated from positional arguments](https://bugs.ruby-lang.org/issues/14183) on Ruby 3
    - `FileUtils.touch` cannot accept Hash as optional argument.

# Related
- If remove support for old Rails versions, this PR should be ignored.
  - https://github.com/rails/spring/pull/617


Fixes https://github.com/rails/spring/issues/614

