### PR TITLE
Fix does not watch `gems.locked`

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -117,7 +117,7 @@ module Spring
       raise e unless initialized?
     ensure
       watcher.add loaded_application_features
-      watcher.add Spring.gemfile, "#{Spring.gemfile}.lock"
+      watcher.add Spring.gemfile, Spring.gemfile_lock
 
       if defined?(Rails) && Rails.application
         watcher.add Rails.application.paths["config/initializers"]

--- a/lib/spring/configuration.rb
+++ b/lib/spring/configuration.rb
@@ -12,6 +12,15 @@ module Spring
       end
     end
 
+    def gemfile_lock
+      case gemfile.to_s
+      when /\bgems\.rb\z/
+        gemfile.sub_ext('.locked')
+      else
+        gemfile.sub_ext('.lock')
+      end
+    end
+
     def after_fork_callbacks
       @after_fork_callbacks ||= []
     end

--- a/lib/spring/configuration.rb
+++ b/lib/spring/configuration.rb
@@ -6,7 +6,7 @@ module Spring
 
     def gemfile
       if /\s1.9.[0-9]/ ===  Bundler.ruby_scope.gsub(/[\/\s]+/,'')
-        ENV["BUNDLE_GEMFILE"] || "Gemfile"
+        Pathname.new(ENV["BUNDLE_GEMFILE"] || "Gemfile").expand_path
       else
         Bundler.default_gemfile
       end


### PR DESCRIPTION
# Why
- Added `gems.rb` supprt at https://github.com/rails/spring/pull/588 .
- But watcher watches wrong file: `gems.rb.lock` .

# What
- Ensure watch `gems.locked` when using `gems.rb` .

# Related
- https://github.com/rails/spring/pull/627
  - If forked process can depend bundler , Can I use `Bundler::SharedHelpers`'s [methods](https://github.com/rubygems/rubygems/blob/5bb55832ccaa91c229564142c906f959db4dab4c/bundler/lib/bundler/shared_helpers.rb#L13-L32) to shrink loaded file size.
  - If cannot, Should we implement finding _gemfile_ logic?