### PR TITLE
Fix watcher test for Ruby 3

### DIFF
--- a/test/support/watcher_test.rb
+++ b/test/support/watcher_test.rb
@@ -31,9 +31,7 @@ module Spring
       end
 
       def touch(file, mtime = nil)
-        options = {}
-        options[:mtime] = mtime if mtime
-        FileUtils.touch(file, options)
+        FileUtils.touch(file, mtime: mtime)
       end
 
       def assert_stale


### PR DESCRIPTION
| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/9955/97068626-4b10bb00-1604-11eb-910b-3042299497e5.png) | ![image](https://user-images.githubusercontent.com/9955/97068632-519f3280-1604-11eb-8775-3343153d1722.png)|


# Why
- Now unit test fails on Ruby 3
  - `ArgumentError: wrong number of arguments (given 2, expected 1)` ([here](https://github.com/rails/spring/blob/d7b21ff9afcaf1f5904b7a2286e2a8201728cb54/test/support/watcher_test.rb#L36))
- [Keyword arguments are now separated from positional arguments](https://bugs.ruby-lang.org/issues/14183) on Ruby 3
  - `FileUtils.touch` cannot accept Hash as optional argument.

# What
- Use keyword argument instead of Has as optional argument
  - `FileUtils.touch` accepts keyword argument since Ruby 2.4 ([commit](https://github.com/ruby/ruby/commit/baa43cd0c2217548c9e19366056fdc5fbd50fa4a))
  - Spring supports Ruby 2.4 over.

# Other fails
- Acceptance test fails on undef Rais 5.1
  - https://github.com/rails/spring/pull/630
- Environment setup fails on Ruby 2.4.x
  - `sprockets requires Ruby version >= 2.5.0. The current ruby version is 2.4.6.354.`
  - Officially support Ruby 2.4.x ?
- Environment set fails on Rails 5.2 with Ruby 2
  - `/home/travis/.rvm/gems/ruby-head/gems/activesupport-5.2.4.4/lib/active_support/messages/metadata.rb:17:in `wrap': wrong number of arguments (given 2, expected 1) (ArgumentError)`
  - Maybe rails matter, should ignore this patter of test.

# Related
- https://github.com/rails/spring/issues/625
  - Now, test on [2.4, 2.5, 2.6 and 3.0 (ruby-head)](https://github.com/rails/spring/blob/d7b21ff9afcaf1f5904b7a2286e2a8201728cb54/.travis.yml#L4-L7)
  - Should we test on 2.7?
