### PR TITLE
Add `rails db:migrate` to Spring-enhanced commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next Release
 
+## 2.1.2
+
+* Add `rails db:migrate` to Spring-enhanced commands
+
 ## 2.1.1
 
 * Avoid -I rubylibdir with default-gem bundler

--- a/lib/spring/client/rails.rb
+++ b/lib/spring/client/rails.rb
@@ -3,7 +3,7 @@ require "set"
 module Spring
   module Client
     class Rails < Command
-      COMMANDS = Set.new %w(console runner generate destroy test)
+      COMMANDS = Set.new %w(console runner generate destroy test db:migrate)
 
       ALIASES = {
         "c" => "console",
@@ -21,7 +21,7 @@ module Spring
         command_name = ALIASES[args[1]] || args[1]
 
         if COMMANDS.include?(command_name)
-          Run.call(["rails_#{command_name}", *args.drop(2)])
+          Run.call(["rails_#{command_name.gsub(':', '_')}", *args.drop(2)])
         else
           require "spring/configuration"
           ARGV.shift

--- a/lib/spring/commands/rails.rb
+++ b/lib/spring/commands/rails.rb
@@ -33,6 +33,12 @@ module Spring
       end
     end
 
+    class RailsDbMigrate < Rails
+      def command_name
+        "db:migrate"
+      end
+    end
+
     class RailsGenerate < Rails
       def command_name
         "generate"
@@ -103,10 +109,11 @@ module Spring
       end
     end
 
-    Spring.register_command "rails_console",  RailsConsole.new
-    Spring.register_command "rails_generate", RailsGenerate.new
-    Spring.register_command "rails_destroy",  RailsDestroy.new
-    Spring.register_command "rails_runner",   RailsRunner.new
-    Spring.register_command "rails_test",     RailsTest.new
+    Spring.register_command "rails_console",    RailsConsole.new
+    Spring.register_command "rails_db_migrate", RailsDbMigrate.new
+    Spring.register_command "rails_generate",   RailsGenerate.new
+    Spring.register_command "rails_destroy",    RailsDestroy.new
+    Spring.register_command "rails_runner",     RailsRunner.new
+    Spring.register_command "rails_test",       RailsTest.new
   end
 end


### PR DESCRIPTION
I noticed recently that running `bin/rails db:migrate` on our app is much slower than `bin/rake db:migrate` and tracked that down to `db:migrate` not being a Spring-enhanced command. Given that many Rails developers run this command quite often, possibly more often than some of the other Spring-enhanced commands, it seemed to make sense to add it.

I wasn't sure if I should add all of the `db:migrate*` tasks (e.g. `db:migrate:redo`). Since `db:migrate` probably gets run much more often that those others in many use cases this seems to satisfy the 80/20 rule. I'm happy to add those other commands if that's desired.

I didn't see any test coverage for similar commands, let me know if I should add anything.

Thank you!
