### PR TITLE
Fix hanging consoles: Close other client sockets in spring application forks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next Release
 
+* Fix bug which makes rails consoles to hang at exit when multiple of them are open (#647)
+
 ## 2.1.1
 
 * Avoid -I rubylibdir with default-gem bundler


### PR DESCRIPTION
All client unix sockets are initiated at the spring application process before forking to serve each client. 
A reference to the client socket remains active by the thread in the wait method waiting for the client's fork to exit.

This is problematic in cases with more than one parallel clients because the client socket for the first client is also present
in the fork for the second client due to fd inheritance from the spring application parent process.

With the first client's socket being present in the second client's fork, the first client cannot exit gracefully because 
a reference to its socket remains open in the fork for the second client leading to rails console hanging
for the first client until the second client gets terminated:

https://github.com/rails/spring/blob/577cf01f232bb6dbd0ade7df2df2ac209697e741/lib/spring/client/run.rb#L167-L171

For read to return & release the client, all references to the socket should be closed.

The problem can be reproduced by opening 2 rails consoles on spring & attempting to exit the first console while 
the second is still active.