### PR TITLE
Fix Rails 7.0 compatibility

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -100,7 +100,9 @@ module Spring
       # override the effect of config.cache_classes = true. We can then actually
       # set config.cache_classes = false after loading the environment.
       Rails::Application.initializer :initialize_dependency_mechanism, group: :all do
-        ActiveSupport::Dependencies.mechanism = :load
+        if ActiveSupport::Dependencies.respond_to?(:mechanism=)
+          ActiveSupport::Dependencies.mechanism = :load
+        end
       end
 
       require Spring.application_root_path.join("config", "environment")


### PR DESCRIPTION
Fix: #649 

```
~/gems/spring-2.1.1/lib/spring/application.rb:103:in `block in preload':
undefined method `mechanism=' for ActiveSupport::Dependencies:Module (NoMethodError)
```