### PR TITLE
Require applications to have reloading enabled in the managed environ…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next Release
 
+* Require applications to have reloading enabled in the managed environments.
+
 ## 2.1.1
 
 * Avoid -I rubylibdir with default-gem bundler

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ automatically add `./bin` to your `PATH` when you `cd` into your application.
 Simply create an `.envrc` file with the command `PATH_add bin` in your
 Rails directory.
 
+### Enable reloading
+
+Spring reloads application code, and therefore needs the application to have
+reloading enabled.
+
+Please, make sure `config.cache_classes` is `false` in the environments that
+Spring manages. That setting is typically configured in
+`config/environments/*.rb`. In particular, make sure it is `false` for the
+`test` environment.
+
 ### Usage
 
 For this walkthrough I've generated a new Rails application, and run
@@ -257,12 +267,10 @@ run through Spring, set the `DISABLE_SPRING` environment variable.
 
 ## Class reloading
 
-Spring uses Rails' class reloading mechanism
-(`ActiveSupport::Dependencies`) to keep your code up to date between
-test runs. This is the same mechanism which allows you to see changes
-during development when you refresh the page. However, you may never
-have used this mechanism with your `test` environment before, and this
-can cause problems.
+Spring uses Rails' class reloading mechanism to keep your code up to date
+between test runs. This is the same mechanism which allows you to see changes
+during development when you refresh the page. However, you may never have used
+this mechanism with your `test` environment before, and this can cause problems.
 
 It's important to realise that code reloading means that the constants
 in your application are *different objects* after files have changed:

--- a/test/support/acceptance_test.rb
+++ b/test/support/acceptance_test.rb
@@ -121,6 +121,15 @@ module Spring
         refute_output_includes "bin/rails runner ''", stderr: 'Running via Spring preloader in process'
       end
 
+      test "raises if config.cache_classes is true" do
+        config_path = app.path("config/environments/development.rb")
+        config = File.read(config_path)
+        config.sub!(/config.cache_classes\s*=\s*false/, "config.cache_classes = true")
+        File.write(config_path, config)
+
+        assert_failure "bin/rails runner 1", stderr: "Please, set config.cache_classes to false"
+      end
+
       test "test changes are picked up" do
         assert_speedup do
           assert_success app.spring_test_command, stdout: "0 failures"


### PR DESCRIPTION
Spring changes application configuration on the fly. This has several issues:

1. `ActiveSupport::Dependencies.mechanism=` is a private setter. The public interface to enable reloading in Rails applications is `config.cache_classes`, set in `config/environments/*.rb`.
2. `ActiveSupport::Dependencies.mechanism=` does not even exist in Rails 7.

Note that Rails 6.x applications that were generated with Spring enabled (the default), already had `config.cache_classes = false` generated in `config/environments/test.rb` ([commit](https://github.com/rails/rails/commit/65344f254cde87950c7f176cb7aa09c002a6f882)).

Fixes #649.