### PR TITLE
Stop depending on Set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next Release
 
+* Stop requiring `set` before bundler can select the proper version. This could result in
+  `already defined constant` warnings during boot (#659).
+
 ## 3.1.1
 
 * Fix compatibility issues with code that raises exceptions with frozen backtraces.

--- a/lib/spring/client/binstub.rb
+++ b/lib/spring/client/binstub.rb
@@ -146,7 +146,7 @@ CODE
         @mode   = :add
         @items  = args.drop(1)
                       .map { |name| find_commands name }
-                      .inject(Set.new, :|)
+                      .flatten.uniq
                       .map { |command| Item.new(command) }
       end
 

--- a/lib/spring/client/rails.rb
+++ b/lib/spring/client/rails.rb
@@ -3,7 +3,7 @@ require "set"
 module Spring
   module Client
     class Rails < Command
-      COMMANDS = Set.new %w(console runner generate destroy test)
+      COMMANDS = %w(console runner generate destroy test)
 
       ALIASES = {
         "c" => "console",

--- a/lib/spring/watcher/abstract.rb
+++ b/lib/spring/watcher/abstract.rb
@@ -19,8 +19,8 @@ module Spring
 
         @root        = File.realpath(root)
         @latency     = latency
-        @files       = Set.new
-        @directories = Set.new
+        @files       = {}
+        @directories = {}
         @stale       = false
         @listeners   = []
 
@@ -63,10 +63,10 @@ module Spring
         synchronize {
           items.each do |item|
             if item.directory?
-              directories << item.realpath.to_s
+              directories[item.realpath.to_s] = true
             else
               begin
-                files << item.realpath.to_s
+                files[item.realpath.to_s] = true
               rescue Errno::ENOENT
                 # Race condition. Ignore symlinks whose target was removed
                 # since the check above, or are deeply chained.

--- a/lib/spring/watcher/polling.rb
+++ b/lib/spring/watcher/polling.rb
@@ -91,7 +91,7 @@ module Spring
       end
 
       def expanded_files
-        files + Dir["{#{directories.map { |d| "#{d}/**/*" }.join(",")}}"]
+        (files.keys + Dir["{#{directories.keys.map { |d| "#{d}/**/*" }.join(",")}}"]).uniq
       end
     end
   end

--- a/test/support/watcher_test.rb
+++ b/test/support/watcher_test.rb
@@ -149,13 +149,13 @@ module Spring
       test "add relative path" do
         File.write("#{dir}/foo", "foo")
         watcher.add "foo"
-        assert_equal ["#{dir}/foo"], watcher.files.to_a
+        assert_equal ["#{dir}/foo"], watcher.files.keys
       end
 
       test "add dot relative path" do
         File.write("#{dir}/foo", "foo")
         watcher.add "./foo"
-        assert_equal ["#{dir}/foo"], watcher.files.to_a
+        assert_equal ["#{dir}/foo"], watcher.files.keys
       end
 
       test "add non existent file" do
@@ -167,20 +167,20 @@ module Spring
         File.write("#{dir}/foo", "foo")
         File.write("#{dir}/bar", "bar")
         watcher.add "foo", "bar"
-        assert_equal ["#{dir}/foo", "#{dir}/bar"], watcher.files.to_a
+        assert_equal ["#{dir}/foo", "#{dir}/bar"], watcher.files.keys
       end
 
       test "add files as nested array" do
         File.write("#{dir}/foo", "foo")
         watcher.add [["foo"]]
-        assert_equal ["#{dir}/foo"], watcher.files.to_a
+        assert_equal ["#{dir}/foo"], watcher.files.keys
       end
 
       test "add symlink" do
         File.write("#{dir}/bar", "bar")
         File.symlink("#{dir}/bar", "#{dir}/foo")
         watcher.add './foo'
-        assert_equal ["#{dir}/bar"], watcher.files.to_a
+        assert_equal ["#{dir}/bar"], watcher.files.keys
       end
 
       test "add dangling symlink" do


### PR DESCRIPTION
It is now a gem, and since spring load before bundler if you have multiple `set` versions installed, you might load the wrong one causing already defined constant warnings.

Initially wrongly reported as a bundler issue: https://github.com/rubygems/rubygems/issues/5127

Reported to be my @Bowman-42
