### PR TITLE
Stop requiring Set

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -1,5 +1,4 @@
 require "spring/boot"
-require "set"
 require "pty"
 
 module Spring

--- a/lib/spring/client/binstub.rb
+++ b/lib/spring/client/binstub.rb
@@ -1,5 +1,3 @@
-require 'set'
-
 module Spring
   module Client
     class Binstub < Command

--- a/lib/spring/client/rails.rb
+++ b/lib/spring/client/rails.rb
@@ -1,5 +1,3 @@
-require "set"
-
 module Spring
   module Client
     class Rails < Command

--- a/lib/spring/watcher/abstract.rb
+++ b/lib/spring/watcher/abstract.rb
@@ -1,4 +1,3 @@
-require "set"
 require "pathname"
 require "mutex_m"
 


### PR DESCRIPTION
This is an addition to the https://github.com/rails/spring/pull/659 PR
We stopped using `Set` so it should be unnecessary to require it