### PR TITLE
Lazy-load digest dependency

### DIFF
--- a/lib/spring/env.rb
+++ b/lib/spring/env.rb
@@ -1,5 +1,4 @@
 require "pathname"
-require "digest/md5"
 
 require "spring/version"
 require "spring/configuration"
@@ -41,6 +40,7 @@ module Spring
     end
 
     def application_id
+      require "digest/md5"
       ENV["SPRING_APPLICATION_ID"] || Digest::MD5.hexdigest(RUBY_VERSION + project_root.to_s)
     end
 


### PR DESCRIPTION
I've experienced some pain in running spring and bootsnap together. Symptom is a `Gem::LoadError` thrown when there are conflicting versions of digest installed:

> You have already activated digest 3.0.0, but your Gemfile requires digest 3.1.0. Since digest is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports digest as a default gem. (Gem::LoadError)

Since `digest` is now being included as a default gem in Ruby, it's hard to circumvent the issue without locking `digest` to an older version.

The problem seems to disappear when deferring the require call.

Relevant issues to similar problems:
https://github.com/rails/spring/issues/603
https://github.com/rails/spring/pull/616