### PR TITLE
Add support for SPRING_QUIET environment variable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next Release
 
+* Add support for `SPRING_QUIET` environment variable.
+
 ## 4.0.0
 
 * Stop requiring `set` before bundler can select the proper version. This could result in

--- a/README.md
+++ b/README.md
@@ -388,6 +388,12 @@ a command runs:
 Spring.quiet = true
 ```
 
+You can also set the initial state of the `quiet` configuration option to true
+by setting the `SPRING_QUIET` environment variable before executing Spring.
+This is useful if you want to set quiet mode when invoking the Spring executable
+in a subprocess, and cannot or prefer not to set it programmatically
+via the `Spring.quiet` option in `~/.spring.rb` or the app's `config/spring.rb`.
+
 ### Environment variables
 
 The following environment variables are used by Spring:
@@ -412,6 +418,8 @@ The following environment variables are used by Spring:
   the long-running Spring server process. By default, this is related to
   the socket path; if the socket path is `/foo/bar/spring.sock` the
   pidfile will be `/foo/bar/spring.pid`.
+* `SPRING_QUIET` - If set, the initial state of the `Spring.quiet`
+  configuration option will default to `true`.
 * `SPRING_SERVER_COMMAND` - The command to run to start up the Spring
   server when it is not already running. Defaults to `spring _[version]_
   server --background`.

--- a/lib/spring/configuration.rb
+++ b/lib/spring/configuration.rb
@@ -2,7 +2,8 @@ require "spring/errors"
 
 module Spring
   class << self
-    attr_accessor :application_root, :quiet
+    attr_accessor :application_root
+    attr_writer :quiet
 
     def gemfile
       require "bundler"
@@ -50,6 +51,10 @@ module Spring
 
     def project_root_path
       @project_root_path ||= find_project_root(Pathname.new(File.expand_path(Dir.pwd)))
+    end
+
+    def quiet
+      @quiet ||= ENV.key?('SPRING_QUIET') 
     end
 
     private

--- a/test/support/acceptance_test.rb
+++ b/test/support/acceptance_test.rb
@@ -125,9 +125,14 @@ module Spring
         assert_success app.spring_test_command, stderr: "Running via Spring preloader in process"
       end
 
-      test "does not tell the user that Spring is being used when used automatically via binstubs but quiet is enabled" do
+      test "does not tell the user that Spring is being used when quiet is enabled via Spring.quiet" do
         File.write("#{app.user_home}/.spring.rb", "Spring.quiet = true")
         assert_success "bin/rails runner ''"
+        refute_output_includes "bin/rails runner ''", stderr: 'Running via Spring preloader in process'
+      end
+
+      test "does not tell the user that Spring is being used when quiet is enabled via SPRING_QUIET ENV var" do
+        assert_success "SPRING_QUIET=true bin/rails runner ''"
         refute_output_includes "bin/rails runner ''", stderr: 'Running via Spring preloader in process'
       end
 


### PR DESCRIPTION
Adds support for enabling quiet mode via `SPRING_QUIET` environment variable.

This is useful in situations where you don't want to put `Spring.quiet = true` in `~/.spring.rb` or your app's `config/spring.rb`, but want to enable quiet mode on a case-by-case basis.

See more details in the doc updates in this PR.

Closes #467