### PR TITLE
add requirement for Bundler 2.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ boot it every time you run a test, rake task or migration.
 
 * Ruby versions: MRI 2.7, MRI 3.0, MRI 3.1
 * Rails versions: 6.0, 6.1, 7.0
+* Bundler v2.1+
 
 Spring makes extensive use of `Process.fork`, so won't be able to
 provide a speed up on platforms which don't support forking (Windows, JRuby).


### PR DESCRIPTION
Spring 4.0.0 uses with_unbundled_env which is only available with Bundler 2.1 (see
https://bundler.io/v2.1/whats_new.html#helper-deprecations)

This has caused issues with some people using e.g Bundler v1 https://github.com/rails/spring/issues/663