### PR TITLE
Run without error if spring is in uninstalled group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ with.
 
 * Fix a small compatibility issue with Ruby 3.2 causing `Kernel#raise` to not accept a `cause`.
 
+* Skip spring without error if spring is not in installed bundler groups.
+
 ## 4.1.0
 
 * Fix bug which makes commands to freeze when the Rails application is writing to STDERR.

--- a/lib/spring/client/binstub.rb
+++ b/lib/spring/client/binstub.rb
@@ -26,7 +26,7 @@ module Spring
         if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
           require "bundler"
 
-          Bundler.locked_gems.specs.find { |spec| spec.name == "spring" }&.tap do |spring|
+          Bundler.definition.requested_specs.find { |spec| spec.name == "spring" }&.tap do |spring|
             Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
             gem "spring", spring.version
             require "spring/binstub"

--- a/test/support/acceptance_test.rb
+++ b/test/support/acceptance_test.rb
@@ -76,9 +76,12 @@ module Spring
 
       def without_gem(name)
         gem_home = app.gem_home.join('gems')
+        spec_home = app.gem_home.join('specifications')
         FileUtils.mv(gem_home.join(name), app.root)
+        FileUtils.mv(spec_home.join("#{name}.gemspec"), app.root)
         yield
       ensure
+        FileUtils.mv(app.root.join("#{name}.gemspec"), spec_home)
         FileUtils.mv(app.root.join(name), gem_home)
       end
 
@@ -304,6 +307,15 @@ module Spring
       test "binstub when spring gem is missing" do
         without_gem "spring-#{Spring::VERSION}" do
           File.write(app.gemfile, app.gemfile.read.gsub(/gem 'spring.*/, ""))
+          app.run! "bundle install", timeout: 300
+          assert_success "bin/rake -T", stdout: "rake db:migrate"
+        end
+      end
+
+      test "binstub when spring gem is in uninstalled group" do
+        without_gem "spring-#{Spring::VERSION}" do
+          File.write(app.gemfile, app.gemfile.read.gsub(/(gem 'spring.*)/, '\1, group: :debug'))
+          app.run! "bundle config set without debug"
           app.run! "bundle install", timeout: 300
           assert_success "bin/rake -T", stdout: "rake db:migrate"
         end


### PR DESCRIPTION
We couldn't run the console on our production server since updating our binstubs with #662. Our setup has not been considered in that change but we found an easy change to the spring binstub which I'm sharing here.

We have spring in the development and test groups which means that it's present in the Gemfile but not installed on production. We are also not using the RAILS_ENV variable when logging in as developer and start a console with a parameter:

    ./bin/rails console -e production

In this case, a Gem::LoadError was raised when trying to load spring. So since checking the RAILS_ENV is not a reliable detection of spring being installed, we added a rescue call.

But looking into this issue further, I discovered that we can go through the list of actually requested gems and skip spring if it wasn't requested. This solves our specific case. A rescue statement may still be useful if other people have other reasons for the gem not being installed but I don't know if that's possible. An alternative or additional patch is available if you are interested but it may not be necessary:  https://github.com/rails/spring/compare/main...mkllnk:handle-missing-gem