### PR TITLE
Don't load spring gem in bin/spring when spring is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next Release
 
+* Don't load spring gem in bin/spring when spring is disabled
+
 ## 4.1.0
 
 * * Fix bug which makes commands to freeze when the Rails application is writing to STDERR.

--- a/lib/spring/client/binstub.rb
+++ b/lib/spring/client/binstub.rb
@@ -23,7 +23,7 @@ module Spring
         # This file loads Spring without using loading other gems in the Gemfile, in order to be fast.
         # It gets overwritten when you run the `spring binstub` command.
 
-        if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
+        if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"] && !ENV["DISABLE_SPRING"])
           require "bundler"
 
           Bundler.locked_gems.specs.find { |spec| spec.name == "spring" }&.tap do |spring|


### PR DESCRIPTION
This disables the loading of the spring gem in `bin/spring` when spring id disabled.

This code fix addresses a bug that occurs under the following circumstances:

- A rails project has spring installed for developers as a development depencency
- The automated tests are run in a test container that has the test dependencies, but not the development depencencies
- The tests contain this recommend block from Active Record
```
# Checks for pending migrations and applies them before tests are run.
# If you are not using ActiveRecord, you can remove these lines.
begin
  ActiveRecord::Migration.maintain_test_schema!
rescue ActiveRecord::PendingMigrationError => exception
  puts exception.to_s.strip
  exit 1
end
```
- That code invokes this line from ActiveRecord: https://github.com/rails/rails/blob/08b3cc3d3254d92647a0812a9c9b6f8b22375ac6/activerecord/lib/active_record/migration.rb#L652
`system("bin/rails db:test:prepare")`
- The `bin/rails` call runs bin/spring
- `bin/spring` attempts to load the spring gem which fails

With the additional check for `SPRING_DISABLED` env variable, rails tests do not attempt to load spring when the env variable is set.