### PR TITLE
Fix the Kernel#raise patch to be Ruby 3.2 compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.7', '3.0.2', '3.1', 'head' ]
+        ruby: [ '2.7', '3.0.2', '3.1', '3.2', 'head' ]
         rails: [ '6.0', '6.1', '7.0', 'edge' ]
         exclude:
           - ruby: '3.1'
             rails: '6.0'
           - ruby: '3.1'
+            rails: '6.1'
+          - ruby: '3.2'
+            rails: '6.0'
+          - ruby: '3.2'
             rails: '6.1'
 
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next Release
 
+* Fix a small compatibility issue with Ruby 3.2 causing `Kernel#raise` to not accept a `cause`.
+
 ## 4.1.0
 
 * * Fix bug which makes commands to freeze when the Rails application is writing to STDERR.

--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -302,9 +302,9 @@ module Spring
       Kernel.module_eval do
         old_raise = Kernel.method(:raise)
         remove_method :raise
-        define_method :raise do |*args|
+        define_method :raise do |*args, **kwargs|
           begin
-            old_raise.call(*args)
+            old_raise.call(*args, **kwargs)
           ensure
             if $!
               lib = File.expand_path("..", __FILE__)


### PR DESCRIPTION
`raise` can take a `cause:` keyword argument. This somehow worked until 3.1 but now longer does in 3.2.

e.g.

```ruby
raise Error, "message", [], cause: nil
```