### PR TITLE
Add MRI3.2 to supported versions documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ boot it every time you run a test, rake task or migration.
 
 ## Compatibility
 
-* Ruby versions: MRI 2.7, MRI 3.0, MRI 3.1
+* Ruby versions: MRI 2.7, MRI 3.0, MRI 3.1, MRI 3.2
 * Rails versions: 6.0, 6.1, 7.0
 * Bundler v2.1+
 


### PR DESCRIPTION
There are some PRs/Codes that look like the Spring has been already supported MRI3.2. For example:

* https://github.com/rails/spring/blob/3fd5c16a4693fbcc7f0840939e225a40c5f250aa/.github/workflows/ci.yml#L9
* https://github.com/rails/spring/pull/691

However, documents does not have text that shows support for MRI3.2.