### PR TITLE
Add `mutex_m` to runtime dependency

### DIFF
--- a/spring.gemspec
+++ b/spring.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.7.0"
 
+  gem.add_dependency 'mutex_m'
+
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'bump'
   gem.add_development_dependency 'activesupport'


### PR DESCRIPTION
This PR adds `mutex_m` to runtime dependency to suppress the following Ruby 3.3's warning:

```console
$ ruby -v
ruby 3.3.0dev (2023-08-03T00:11:08Z master 4b6c584023) [x86_64-darwin22]

$ spring start
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/spring-4.1.1/lib/spring/watcher/abstract.rb:2:
warning: mutex_m which is not part of the default gems since Ruby 3.4.0
```

Related PR ... https://github.com/rails/rails/pull/48907