### PR TITLE
Drop dependency on mutex_m

### DIFF
--- a/lib/spring/watcher/polling.rb
+++ b/lib/spring/watcher/polling.rb
@@ -12,7 +12,7 @@ module Spring
       end
 
       def check_stale
-        synchronize do
+        @mutex.synchronize do
           computed = compute_mtime
           if mtime < computed
             debug { "check_stale: mtime=#{mtime.inspect} < computed=#{computed.inspect}" }

--- a/spring.gemspec
+++ b/spring.gemspec
@@ -15,8 +15,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.7.0"
 
-  gem.add_dependency 'mutex_m'
-
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'bump'
   gem.add_development_dependency 'activesupport'


### PR DESCRIPTION
It doesn't really save much effort, and it's being extracted as a gem which cause issues for projects like spring that often are loaded before bundler.

Reported by @tisba 