### PR TITLE
Add Spring.reset_on_env

### DIFF
--- a/lib/spring/configuration.rb
+++ b/lib/spring/configuration.rb
@@ -36,6 +36,10 @@ module Spring
       @spawn_on_env ||= []
     end
 
+    def reset_on_env
+      @reset_on_env ||= []
+    end
+
     def verify_environment
       application_root_path
     end


### PR DESCRIPTION
Closes https://github.com/rails/spring/issues/420

Spring needs to restart when certain important environment variables change (eg. DATABASE_URL). Without this, comamnds connect to a stale application instance that has been booted with incorrect config.

Configuration must be set in `config/spring_client.rb`:

```rb
Spring.reset_on_env << "SOME_ENV"
```

So it can be used like this:
```sh
> export SOME_ENV=1 # exports env
> bin/rails runner "" # start server
> SOME_ENV=2 bin/rails runner "" # restarts server
```