### PR TITLE
Bring back `Spring::Watcher::Abstract#synchronize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next Release
 
+* Bring back `Spring::Watcher::Abstract#synchronize` method to fix compatibility with `spring-watcher-listen`.
+
 ## 4.1.2
 
 * Drop dependency on `mutex_m`. Avoid issues with loading the wrong version before bundler kicks in.

--- a/lib/spring/watcher/abstract.rb
+++ b/lib/spring/watcher/abstract.rb
@@ -22,6 +22,11 @@ module Spring
         @on_debug    = nil
       end
 
+      def synchronize(&block)
+        # Used by some gems.
+        @mutex.synchronize(&block)
+      end
+
       def on_debug(&block)
         @on_debug = block
       end


### PR DESCRIPTION
Fix: https://github.com/rails/spring-watcher-listen/issues/36