### PR TITLE
Add timeout when connecting to server

### DIFF
--- a/lib/spring/client/run.rb
+++ b/lib/spring/client/run.rb
@@ -114,6 +114,10 @@ module Spring
       end
 
       def verify_server_version
+        unless IO.select([server], [], [], CONNECT_TIMEOUT)
+          raise "Error connecting to Spring server"
+        end
+
         server_version = server.gets.chomp
         if server_version != env.version
           $stderr.puts "There is a version mismatch between the Spring client " \

--- a/lib/spring/client/run.rb
+++ b/lib/spring/client/run.rb
@@ -118,7 +118,12 @@ module Spring
           raise "Error connecting to Spring server"
         end
 
-        server_version = server.gets.chomp
+        line = server.gets
+        unless line
+          raise "Error connecting to Spring server"
+        end
+
+        server_version = line.chomp
         if server_version != env.version
           $stderr.puts "There is a version mismatch between the Spring client " \
                          "(#{env.version}) and the server (#{server_version})."


### PR DESCRIPTION
Over on https://github.com/rails/spring/issues/663 we've seen the spring server get into a funky state, where the `server.gets` just hangs indefinitely.

I found other places in client.rb that checked that there was something to read before reading, and made sure `server.gets` returns something. So, applied that to `verify_server_version` 😁 