### PR TITLE
Remove incorrect version constraint

### DIFF
--- a/test/support/acceptance_test.rb
+++ b/test/support/acceptance_test.rb
@@ -12,9 +12,7 @@ module Spring
 
       def rails_version
         if ENV['RAILS_VERSION'] == "edge"
-          "7.1.0.alpha"
-        elsif ENV['RAILS_VERSION'] == "7.0"
-          ">= 7.0.0.alpha"
+          ">= 7.1.0.alpha"
         else
           "~> #{ENV['RAILS_VERSION'] || "6.1"}.0"
         end


### PR DESCRIPTION
Because Rails 7.1 is released, >= 7.0.0.alpha would install 7.1, and a nokogiri version that doesn't work on Ruby 2.7. This caused 2.7 / 7.0 CI to fail.

Also use >= 7.1.0.alpha in edge case, there is no prerelease right now.