### PR TITLE
Update supported rails version documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ boot it every time you run a test, rake task or migration.
 ## Compatibility
 
 * Ruby versions: MRI 2.7, MRI 3.0, MRI 3.1, MRI 3.2
-* Rails versions: 6.0, 6.1, 7.0
+* Rails versions: 6.1, 7.0, 7.1
 * Bundler v2.1+
 
 Spring makes extensive use of `Process.fork`, so won't be able to


### PR DESCRIPTION
I believe that the support version of Rails has changed from [this commit](https://github.com/rails/spring/commit/de5eacfb8671d3e0acd21a9d38c7296e3437afcc).