### PR TITLE
Fixed a small typo in the CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 4.2.0
 
 * Added `Spring.reset_on_env` to define environment variables which should cause spring to reload when they change.
-* Added `Spring.spawn_on_en` to define environment variables that should cause spring to start a distinct server.
+* Added `Spring.spawn_on_env` to define environment variables that should cause spring to start a distinct server.
 * Better handle a case where the server could hang.
 
 ## 4.1.3


### PR DESCRIPTION
Just a single missing letter `Spring.spawn_on_en` » `Spring.spawn_on_env`