### PR TITLE
Recommend setting `enable_reloading` on newer Rails versions

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -102,9 +102,14 @@ module Spring
 
       Rails::Application.initializer :ensure_reloading_is_enabled, group: :all do
         if Rails.application.config.cache_classes
+          config_name, set_to = if Rails.application.config.respond_to?(:enable_reloading=)
+            ["enable_reloading", "true"]
+          else
+            ["cache_classes", "false"]
+          end
           raise <<-MSG.strip_heredoc
             Spring reloads, and therefore needs the application to have reloading enabled.
-            Please, set config.cache_classes to false in config/environments/#{Rails.env}.rb.
+            Please, set config.#{config_name} to #{set_to} in config/environments/#{Rails.env}.rb.
           MSG
         end
       end

--- a/test/support/acceptance_test.rb
+++ b/test/support/acceptance_test.rb
@@ -144,7 +144,12 @@ module Spring
         end
         File.write(config_path, config)
 
-        assert_failure "bin/rails runner 1", stderr: "Please, set config.cache_classes to false"
+        expected_error = Regexp.union(
+          "Please, set config.enable_reloading to true",
+          "Please, set config.cache_classes to false"
+        )
+
+        assert_failure "bin/rails runner 1", stderr: expected_error
       end
 
       test "test changes are picked up" do


### PR DESCRIPTION
README recommends to set newer `enable_reloading` config 
https://github.com/rails/spring/blob/b6dc87e62d6c2192a2ba46782804e2790ec8e5f7/README.md?plain=1#L74

while the raised message still asks to tweak old `cache_classes` config which may eventually be removed.

Let's update the error to ask applications to configure `enable_reloading` where available.

Does checking for `respond_to?` seems reasonable? Any reason to check Rails version instead? 