### PR TITLE
Add changelog_uri to gemspec

### DIFF
--- a/spring.gemspec
+++ b/spring.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new do |gem|
 
   gem.metadata = {
     "rubygems_mfa_required" => "true",
+    "changelog_uri" => "https://github.com/rails/spring/blob/main/CHANGELOG.md"
   }
 end


### PR DESCRIPTION
Documented here: https://guides.rubygems.org/specification-reference/#metadata 

Useful for running https://github.com/MaximeD/gem_updater