### PR TITLE
Watch app embedded engine initializers

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -124,6 +124,11 @@ module Spring
 
       if defined?(Rails) && Rails.application
         watcher.add Rails.application.paths["config/initializers"]
+        Rails::Engine.descendants.each do |engine|
+          if engine.root.to_s.start_with?(Rails.root.to_s)
+            watcher.add engine.paths["config/initializers"].expanded
+          end
+        end
         watcher.add Rails.application.paths["config/database"]
         if secrets_path = Rails.application.paths["config/secrets"]
           watcher.add secrets_path


### PR DESCRIPTION
I want to be able to configure spring's file watcher to watch additional files when booting my app. Specifically, I want to update Rails to watch the `config/initializers` directory of engines defined within the application, so that spring will automatically reload when updating those initializers like it does with the root `config/initializers`.

By iterating engine descendants we can watch paths that intersect with `Rails.root`.