### PR TITLE
Fix Server crash when Client times out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next Release
 
+* Fixed Server crash when the Client times out or otherwise disconnects
+
 ## 4.2.1
 
 * Added `Spring.connect_timeout` and `Spring.boot_timeout` to allow to increase timeout for larger apps.

--- a/lib/spring/server.rb
+++ b/lib/spring/server.rb
@@ -74,6 +74,8 @@ module Spring
       end
     rescue SocketError => e
       raise e unless client.eof?
+    rescue Errno::EPIPE => e
+      log "client disconnected with error #{e.message}, ignoring command"
     ensure
       redirect_output
     end


### PR DESCRIPTION
Fixes #724

This fixes an issue where, when the Spring client times out or otherwise disconnects from the server, that the server crashes with a `Broken pipe (Errno::EPIPE)` error.