### PR TITLE
Prevent server crash by restarting child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next Release
 
+* Fixed a bug that would crash the server if sending IO to the child failed
+
 ## 4.2.1
 
 * Added `Spring.connect_timeout` and `Spring.boot_timeout` to allow to increase timeout for larger apps.

--- a/lib/spring/application_manager.rb
+++ b/lib/spring/application_manager.rb
@@ -42,7 +42,7 @@ module Spring
         if alive?
           begin
             yield
-          rescue Errno::ECONNRESET, Errno::EPIPE
+          rescue Errno::ECONNRESET, Errno::EPIPE, Errno::EINVAL
             # The child has died but has not been collected by the wait thread yet,
             # so start a new child and try again.
             log "child dead; starting"


### PR DESCRIPTION
Before this change, if Errno::EINVAL is thrown when sending IO to the child the server would crash. Now we catch the exception and, assuming the child has problems, we start a new child.