### PR TITLE
Remove 3.1 + edge from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
           - ruby: '3.3'
             rails: '7.1'
             rubyopt: "--enable-frozen-string-literal"
+        exclude:
+          - ruby: '3.1'
+            rails: 'edge'
+            rubyopt: ''
 
     env:
       RAILS_VERSION: ${{ matrix.rails }}


### PR DESCRIPTION
Rails 8 needs 3.2+ so this will never pass. We can just drop this from CI.