### PR TITLE
Default to using spring when running commands and tasks with bin/rails

### DIFF
--- a/lib/spring/client/rails.rb
+++ b/lib/spring/client/rails.rb
@@ -1,14 +1,12 @@
 module Spring
   module Client
     class Rails < Command
-      COMMANDS = %w(console runner generate destroy test)
+      SPECIAL_COMMANDS = %w(test)
+      EXCLUDED_COMMANDS = %w(server)
 
       ALIASES = {
-        "c" => "console",
-        "r" => "runner",
-        "g" => "generate",
-        "d" => "destroy",
-        "t" => "test"
+        "t" => "test",
+        "s" => "server"
       }
 
       def self.description
@@ -18,15 +16,15 @@ module Spring
       def call
         command_name = ALIASES[args[1]] || args[1]
 
-        if COMMANDS.include?(command_name)
-          Run.call(["rails_#{command_name}", *args.drop(2)])
-        elsif command_name&.start_with?("db:") && !command_name.start_with?("db:system")
-          Run.call(["rake", *args.drop(1)])
-        else
+        if SPECIAL_COMMANDS.include?(command_name)
+          Run.call(["rails_#{command_name}", *args.drop(1)])
+        elsif EXCLUDED_COMMANDS.include?(command_name)
           require "spring/configuration"
           ARGV.shift
           load Dir.glob(Spring.application_root_path.join("{bin,script}/rails")).first
           exit
+        else
+          Run.call(["rails", *args.drop(1)])
         end
       end
     end

--- a/lib/spring/commands/rails.rb
+++ b/lib/spring/commands/rails.rb
@@ -2,8 +2,21 @@ module Spring
   module Commands
     class Rails
       def call
-        ARGV.unshift command_name
         load Dir.glob(::Rails.root.join("{bin,script}/rails")).first
+      end
+
+      def env(args)
+        environment = nil
+
+        args.each.with_index do |arg, i|
+          if arg =~ /(-e|--environment)=(\w+)/
+            environment = $2
+          elsif i > 0 && %w[-e --environment].include?(args[i - 1])
+            environment = arg
+          end
+        end
+
+        environment
       end
 
       def description
@@ -11,102 +24,13 @@ module Spring
       end
     end
 
-    class RailsConsole < Rails
-      def env(args)
-        return args.first if args.first && !args.first.index("-")
-
-        environment = nil
-
-        args.each.with_index do |arg, i|
-          if arg =~ /--environment=(\w+)/
-            environment = $1
-          elsif i > 0 && args[i - 1] == "-e"
-            environment = arg
-          end
-        end
-
-        environment
-      end
-
-      def command_name
-        "console"
-      end
-    end
-
-    class RailsGenerate < Rails
-      def command_name
-        "generate"
-      end
-    end
-
-    class RailsDestroy < Rails
-      def command_name
-        "destroy"
-      end
-    end
-
-    class RailsRunner < Rails
-      def call
-        ARGV.replace extract_environment(ARGV).first
-        super
-      end
-
-      def env(args)
-        extract_environment(args).last
-      end
-
-      def command_name
-        "runner"
-      end
-
-      def extract_environment(args)
-        environment = nil
-
-        args = args.select.with_index { |arg, i|
-          case arg
-          when "-e"
-            false
-          when /--environment=(\w+)/
-            environment = $1
-            false
-          else
-            if i > 0 && args[i - 1] == "-e"
-              environment = arg
-              false
-            else
-              true
-            end
-          end
-        }
-
-        [args, environment]
-      end
-    end
-
     class RailsTest < Rails
       def env(args)
-        environment = "test"
-
-        args.each.with_index do |arg, i|
-          if arg =~ /--environment=(\w+)/
-            environment = $1
-          elsif i > 0 && args[i - 1] == "-e"
-            environment = arg
-          end
-        end
-
-        environment
-      end
-
-      def command_name
-        "test"
+        super || "test"
       end
     end
 
-    Spring.register_command "rails_console",  RailsConsole.new
-    Spring.register_command "rails_generate", RailsGenerate.new
-    Spring.register_command "rails_destroy",  RailsDestroy.new
-    Spring.register_command "rails_runner",   RailsRunner.new
+    Spring.register_command "rails",          Rails.new
     Spring.register_command "rails_test",     RailsTest.new
   end
 end

--- a/test/support/acceptance_test.rb
+++ b/test/support/acceptance_test.rb
@@ -740,6 +740,18 @@ module Spring
 
         assert_failure app.spring_test_command, stderr: "omg (RuntimeError)"
       end
+
+      test "speeds up rake tasks with rails commands" do
+        File.write(app.path("lib/tasks/env.rake"), <<-RUBY.strip_heredoc)
+          namespace :foo do
+            task :bar => :environment
+          end
+        RUBY
+
+        assert_speedup do
+          2.times { app.run "bin/rails foo:bar" }
+        end
+      end
     end
   end
 end

--- a/test/unit/commands_test.rb
+++ b/test/unit/commands_test.rb
@@ -2,51 +2,31 @@ require_relative "../helper"
 require "spring/commands"
 
 class CommandsTest < ActiveSupport::TestCase
-  test 'console command sets rails environment from command-line option' do
-    command = Spring::Commands::RailsConsole.new
-    assert_equal 'test', command.env(['test'])
-  end
-
-  test 'console command sets rails environment from -e option' do
-    command = Spring::Commands::RailsConsole.new
+  test 'rails command sets rails environment from -e option' do
+    command = Spring::Commands::Rails.new
     assert_equal 'test', command.env(['-e', 'test'])
+    assert_equal 'test', command.env(['-e=test'])
   end
 
-  test 'console command sets rails environment from --environment option' do
-    command = Spring::Commands::RailsConsole.new
+  test 'rails command sets rails environment from --environment option' do
+    command = Spring::Commands::Rails.new
+    assert_equal 'test', command.env(['--environment', 'test'])
     assert_equal 'test', command.env(['--environment=test'])
   end
 
-  test 'console command ignores first argument if it is a flag except -e and --environment' do
-    command = Spring::Commands::RailsConsole.new
+  test 'rails command ignores first argument if it is a flag except -e and --environment' do
+    command = Spring::Commands::Rails.new
     assert_nil command.env(['--sandbox'])
   end
 
-  test 'Runner#env sets rails environment from command-line option' do
-    command = Spring::Commands::RailsRunner.new
+  test 'rails command uses last environment option' do
+    command = Spring::Commands::Rails.new
+    assert_equal 'development', command.env(['-e', 'test', '--environment=development'])
+  end
+
+  test 'rails command ignores additional arguments' do
+    command = Spring::Commands::Rails.new
     assert_equal 'test', command.env(['-e', 'test', 'puts 1+1'])
-  end
-
-  test 'RailsRunner#env sets rails environment from long form of command-line option' do
-    command = Spring::Commands::RailsRunner.new
-    assert_equal 'test', command.env(['--environment=test', 'puts 1+1'])
-  end
-
-  test 'RailsRunner#env ignores insignificant arguments' do
-    command = Spring::Commands::RailsRunner.new
-    assert_nil command.env(['puts 1+1'])
-  end
-
-  test 'RailsRunner#extract_environment removes -e <env>' do
-    command = Spring::Commands::RailsRunner.new
-    args = ['-b', '-a', '-e', 'test', '-r']
-    assert_equal [['-b', '-a', '-r'], 'test'], command.extract_environment(args)
-  end
-
-  test 'RailsRunner#extract_environment removes --environment=<env>' do
-    command = Spring::Commands::RailsRunner.new
-    args = ['-b', '--environment=test', '-a', '-r']
-    assert_equal [['-b', '-a', '-r'], 'test'], command.extract_environment(args)
   end
 
   test "rake command has configurable environments" do
@@ -57,18 +37,20 @@ class CommandsTest < ActiveSupport::TestCase
     assert_nil command.env(["test_foo"])
   end
 
-  test 'RailsTest#command defaults to test rails environment' do
+  test 'RailsTest#env defaults to test rails environment' do
     command = Spring::Commands::RailsTest.new
     assert_equal 'test', command.env([])
   end
 
-  test 'RailsTest#command sets rails environment from --environment option' do
+  test 'RailsTest#env sets rails environment from --environment option' do
     command = Spring::Commands::RailsTest.new
-    assert_equal 'foo', command.env(['--environment=foo'])
+    assert_equal 'development', command.env(['--environment', 'development'])
+    assert_equal 'development', command.env(['--environment=development'])
   end
 
-  test 'RailsTest#command sets rails environment from -e option' do
+  test 'RailsTest#env sets rails environment from -e option' do
     command = Spring::Commands::RailsTest.new
-    assert_equal 'foo', command.env(['-e', 'foo'])
+    assert_equal 'development', command.env(['-e', 'development'])
+    assert_equal 'development', command.env(['-e=development'])
   end
 end


### PR DESCRIPTION
When you run a rake task with `bin/rails` it does not use spring (except db rake tasks). And, many rails commands that _could_ benefit from using spring do not use it, since the current system is for commands to opt-in.

I believe that it would be better to have an opt-out system rather than an opt-in system, since likely most commands and tasks will benefit from spring. So I implemented that in this PR.

While here I simplified the existing Rails sub-commands implementation, which had varying ways of picking off the environment from the args. I believe we only need one special subcommand, `test` because it needs to default to the `test` environment, unlike the others.

On the other side, I opted out the `server` command because it should not run with spring. Are there any other commands that should opt-out?