### PR TITLE
Pass signaled exit code properly to the client

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -370,10 +370,10 @@ module Spring
       Spring.failsafe_thread {
         begin
           _, status = Process.wait2 pid
-          log "#{pid} exited with #{status.exitstatus}"
+          log "#{pid} exited with #{status.exitstatus || status.inspect}"
 
           streams.each(&:close)
-          client.puts(status.exitstatus)
+          client.puts(status.exitstatus || status.to_i)
           client.close
         ensure
           @mutex.synchronize { @waiting.delete pid }

--- a/lib/spring/client/run.rb
+++ b/lib/spring/client/run.rb
@@ -184,11 +184,16 @@ module Spring
           suspend_resume_on_tstp_cont(pid)
 
           forward_signals(application)
-          status = application.read.to_i
+          status = application.read
+          log "got exit status #{status.inspect}"
 
-          log "got exit status #{status}"
+          # Status should always be an integer. If it is empty, something unexpected must have happened to the server.
+          if status.to_s.strip.empty?
+            log "unexpected empty exit status, app crashed?"
+            exit 1
+          end
 
-          exit status
+          exit status.to_i
         else
           log "got no pid"
           exit 1

--- a/test/support/acceptance_test.rb
+++ b/test/support/acceptance_test.rb
@@ -740,6 +740,16 @@ module Spring
 
         assert_failure app.spring_test_command, stderr: "omg (RuntimeError)"
       end
+
+      test "passes exit code from exit and signal" do
+        artifacts = app.run("bin/rails runner 'Process.exit(7)'")
+        code = artifacts[:status].exitstatus || artifacts[:status].termsig
+        assert_equal 7, code, "Expected exit status to be 7, but was #{code}"
+
+        artifacts = app.run("bin/rails runner 'system(\"kill -7 \#{Process.pid}\")'")
+        code = artifacts[:status].exitstatus || artifacts[:status].termsig
+        assert_equal 7, code, "Expected exit status to be 7, but was #{code}"
+      end
     end
   end
 end

--- a/test/support/acceptance_test.rb
+++ b/test/support/acceptance_test.rb
@@ -748,7 +748,7 @@ module Spring
 
         artifacts = app.run("bin/rails runner 'system(\"kill -7 \#{Process.pid}\")'")
         code = artifacts[:status].exitstatus || artifacts[:status].termsig
-        assert_equal 7, code, "Expected exit status to be 7, but was #{code}"
+        assert_equal 7, code % 128, "Expected exit status to be 7, but was #{code}"
       end
     end
   end


### PR DESCRIPTION
Pass signaled exit code properly to the client

Process::Status#existstatus is nil when child did not exit cleanly. When ruby process crashes, running it with spring masked exit code and returned 0.
This commit allows Spring::Server thread to properly pass application exit code to the client, even when signaled or stopped.

Fixes https://github.com/rails/spring/issues/676.