### PR TITLE
Update version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ boot it every time you run a test, rake task or migration.
 
 ## Compatibility
 
-* Ruby versions: MRI 2.7, MRI 3.0, MRI 3.1, MRI 3.2
-* Rails versions: 6.0, 6.1, 7.0
+* Ruby versions: MRI 2.7+
+* Rails versions: 6.0+
 * Bundler v2.1+
 
 Spring makes extensive use of `Process.fork`, so won't be able to


### PR DESCRIPTION
If I'm not mistaken, spring works with all of these versions.

```diff
## Compatibility

- * Ruby versions: MRI 2.7, MRI 3.0, MRI 3.1, MRI 3.2
- * Rails versions: 6.0, 6.1, 7.0
+ * Ruby versions: MRI 2.7+
+ * Rails versions: 6.0+
```

Correct me if I'm wrong.