### PR TITLE
Eagerly preload framework base classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
-## Next Release
+## Unreleased
 
 * Fixed crashes when a client disconnects mid-handshake (e.g. on connect timeout). Previously, `Errno::EPIPE` raised in `Spring::Server#serve` or `Spring::Application#serve` would propagate up through the accept loop and kill the process, leaving a stale socket that broke every subsequent client. Both crash sites are now rescued, including writes that happen inside the `rescue Exception` handler in `Application#serve` while reporting an earlier failure to the gone client.
+
+* Eagerly autoload framework base classes (`ActionMailer::Base`,
+  `ActionController::Base`, `ActionController::API`) at the end of preload
+  so their `ActiveSupport.on_load` hooks fire in the parent process.
+  Without this, the reloader probe in `#serve` materializes Rails
+  internals (notably ActionView's `CacheExpiry::ViewReloader`) in a
+  half-initialized state and triggers an expensive `FileUpdateChecker`
+  rebuild on every `prepend_view_path` inside each fork. See
+  rails/rails#51308 for the lazy-init contract this aligns with.
 
 ## 4.4.0
 

--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -117,6 +117,7 @@ module Spring
       require Spring.application_root_path.join("config", "environment")
 
       invoke_after_environment_load_callbacks
+      preload_framework_base_classes
 
       disconnect_database
 
@@ -141,6 +142,19 @@ module Spring
         if secrets_path = Rails.application.paths["config/secrets"]
           watcher.add secrets_path
         end
+      end
+    end
+
+    # Eagerly autoload framework base classes
+    FRAMEWORK_BASE_CLASSES = %w[
+      ActionMailer::Base
+      ActionController::Base
+      ActionController::API
+    ].freeze
+
+    def preload_framework_base_classes
+      FRAMEWORK_BASE_CLASSES.each do |const|
+        Object.const_get(const) if Object.const_defined?(const)
       end
     end
 


### PR DESCRIPTION
`Spring::Application#serve` calls `Rails.application.reloaders.any?(&:updated?)` before forking. ActionView's [`CacheExpiry::ViewReloader#updated?`](https://github.com/rails/rails/blob/main/actionview/lib/action_view/cache_expiry.rb) lazily builds a `FileUpdateChecker` from whatever view paths are registered at that moment (lazy-init contract from rails/rails#51308).

Engines register view paths via `prepend_view_path` inside `on_load(:action_mailer)` / `:action_controller_base` blocks. In a fresh preload nothing has referenced those framework classes yet, so `dirs_to_watch` is empty when the probe runs — pinning the watcher empty and triggering a full `FileUpdateChecker` rebuild on every `prepend_view_path` in each fork.

Preloading the framework classes (not `Application*`, per Rafael's suggestion, framework code is never reloaded, app namespace is) targets the `on_load` hooks directly and avoids coupling Spring's preload to user-reloadable code.

While [rails/rails#57269](https://github.com/rails/rails/pull/57269) closes the bug part of this from the Rails side, this still makes sense on it's own.
