### PR TITLE
Add Spring.after_environment_load hook for post-Rails preloading

### DIFF
--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -116,16 +116,7 @@ module Spring
 
       require Spring.application_root_path.join("config", "environment")
 
-      # Run user-supplied post-environment-load callbacks (e.g. preloading the
-      # test runtime so forked children skip 2+s of require chains).
-      Spring.after_environment_load_callbacks.each do |callback|
-        begin
-          callback.call
-        rescue Exception => err
-          log "after_environment_load callback raised: #{err.class}: #{err.message}"
-          raise
-        end
-      end
+      invoke_after_environment_load_callbacks
 
       disconnect_database
 
@@ -307,6 +298,12 @@ module Spring
 
     def invoke_after_fork_callbacks
       Spring.after_fork_callbacks.each do |callback|
+        callback.call
+      end
+    end
+
+    def invoke_after_environment_load_callbacks
+      Spring.after_environment_load_callbacks.each do |callback|
         callback.call
       end
     end

--- a/lib/spring/application.rb
+++ b/lib/spring/application.rb
@@ -116,6 +116,17 @@ module Spring
 
       require Spring.application_root_path.join("config", "environment")
 
+      # Run user-supplied post-environment-load callbacks (e.g. preloading the
+      # test runtime so forked children skip 2+s of require chains).
+      Spring.after_environment_load_callbacks.each do |callback|
+        begin
+          callback.call
+        rescue Exception => err
+          log "after_environment_load callback raised: #{err.class}: #{err.message}"
+          raise
+        end
+      end
+
       disconnect_database
 
       @preloaded = :success

--- a/lib/spring/configuration.rb
+++ b/lib/spring/configuration.rb
@@ -35,6 +35,18 @@ module Spring
       after_fork_callbacks << block
     end
 
+    # Callbacks invoked once on the spring server, after config/environment
+    # has finished loading and Rails autoloads are wired up. Use this to
+    # preload heavy test/dev support files that depend on Rails being ready,
+    # so the forked child doesn't pay the cost on every command.
+    def after_environment_load_callbacks
+      @after_environment_load_callbacks ||= []
+    end
+
+    def after_environment_load(&block)
+      after_environment_load_callbacks << block
+    end
+
     def spawn_on_env
       @spawn_on_env ||= []
     end

--- a/lib/spring/configuration.rb
+++ b/lib/spring/configuration.rb
@@ -35,10 +35,6 @@ module Spring
       after_fork_callbacks << block
     end
 
-    # Callbacks invoked once on the spring server, after config/environment
-    # has finished loading and Rails autoloads are wired up. Use this to
-    # preload heavy test/dev support files that depend on Rails being ready,
-    # so the forked child doesn't pay the cost on every command.
     def after_environment_load_callbacks
       @after_environment_load_callbacks ||= []
     end

--- a/test/support/acceptance_test.rb
+++ b/test/support/acceptance_test.rb
@@ -218,6 +218,22 @@ module Spring
         assert_success app.spring_test_command
       end
 
+      test "app gets reloaded when after_environment_load preloads test_helper" do
+        File.write(app.spring_config, <<-RUBY.strip_heredoc)
+          Spring.after_environment_load do
+            require File.expand_path("../test/test_helper", __dir__)
+          end
+        RUBY
+
+        assert_success app.spring_test_command
+
+        test_helper = app.path("test/test_helper.rb")
+        File.write(test_helper, test_helper.read + "\nraise 'omg'\n")
+
+        app.await_reload
+        assert_failure app.spring_test_command, stderr: /omg \(RuntimeError\)/, log: /child \d+ shutdown/
+      end
+
       test "app recovers when a boot-level error is introduced" do
         config = app.application_config.read
 
@@ -529,6 +545,13 @@ module Spring
       test "after fork callback" do
         File.write(app.spring_config, "Spring.after_fork { puts '!callback!' }")
         assert_success "bin/rails runner 'puts 2'", stdout: "!callback!\n2"
+      end
+
+      test "after environment load callback" do
+        File.write(app.spring_config, "Spring.after_environment_load { puts '!callback!' }")
+
+        assert_success app.spring_test_command, stdout: "!callback!"
+        refute_output_includes app.spring_test_command, stdout: "!callback!"
       end
 
       test "global config file evaluated" do

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -1,0 +1,58 @@
+require_relative "../helper"
+require "spring/configuration"
+
+class ConfigurationTest < ActiveSupport::TestCase
+  test "after_environment_load_callbacks is empty by default" do
+    assert_equal [], Spring.after_environment_load_callbacks
+  end
+
+  test "after_environment_load registers a callback" do
+    callbacks = []
+    Spring.stub(:after_environment_load_callbacks, callbacks) do
+      Spring.after_environment_load { true }
+    end
+    assert_equal 1, callbacks.size
+  end
+
+  test "after_environment_load accumulates multiple callbacks in order" do
+    callbacks = []
+    Spring.stub(:after_environment_load_callbacks, callbacks) do
+      Spring.after_environment_load { :first }
+      Spring.after_environment_load { :second }
+    end
+    assert_equal [:first, :second], callbacks.map(&:call)
+  end
+
+  test "after_environment_load callbacks are independent from after_fork callbacks" do
+    env_callbacks  = []
+    fork_callbacks = []
+    Spring.stub(:after_environment_load_callbacks, env_callbacks) do
+      Spring.stub(:after_fork_callbacks, fork_callbacks) do
+        Spring.after_environment_load { true }
+      end
+    end
+    assert_equal 1, env_callbacks.size
+    assert_equal 0, fork_callbacks.size
+  end
+
+  test "after_fork_callbacks is empty by default" do
+    assert_equal [], Spring.after_fork_callbacks
+  end
+
+  test "after_fork registers a callback" do
+    callbacks = []
+    Spring.stub(:after_fork_callbacks, callbacks) do
+      Spring.after_fork { true }
+    end
+    assert_equal 1, callbacks.size
+  end
+
+  test "after_fork accumulates multiple callbacks in order" do
+    callbacks = []
+    Spring.stub(:after_fork_callbacks, callbacks) do
+      Spring.after_fork { :first }
+      Spring.after_fork { :second }
+    end
+    assert_equal [:first, :second], callbacks.map(&:call)
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `Spring.after_environment_load` hook that runs immediately after the Rails application environment is loaded in the Spring server process, but before `GC.compact`/`Process.warmup` and before the server enters its wait loop.

This hook enables applications to preload expensive test infrastructure (e.g. test helpers, fixture caches, datastore connections) into the Spring server so that forked test workers inherit that work via copy-on-write instead of paying it on every invocation.

## API

```ruby
# config/spring.rb
Spring.after_environment_load do
  require "test_helper"
end
```

The block receives no arguments and runs once per server boot. It is intentionally not called when Spring is disabled or when the environment is reloaded.

## Motivation

In Shopify's monolith, `bin/test` pays ~2.4s of `require` cost for its `test_helper` on every test run even with Spring hot. By preloading this file into the Spring server, forked workers inherit the already-required code via CoW, reducing time-to-first-test significantly for inner-loop development.

## Implementation

- `Spring::Configuration` gains an `@after_environment_load` array and `after_environment_load` registration method (same pattern as `after_fork`).
- `Spring::Application#load_application` calls the callbacks after `require app_env` returns.